### PR TITLE
Add pre-commit hooks and minimal formatting cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,16 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-json
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.0
     hooks:

--- a/examples/osworld-ags/.env.example
+++ b/examples/osworld-ags/.env.example
@@ -7,4 +7,3 @@ AGS_TIMEOUT=36000
 # OpenAI API Configuration
 OPENAI_API_KEY=your_openai_api_key_here
 OPENAI_BASE_URL=https://api.openai.com/v1
-


### PR DESCRIPTION
## Summary

- add a baseline pre-commit configuration with generic repository hygiene hooks plus gitleaks
- keep this PR focused on pre-commit setup with only minimal formatting cleanup

## Verification

- `uvx pre-commit run --files .pre-commit-config.yaml examples/osworld-ags/.env.example`
- `git diff --check`
