### PR TITLE
feat: add deploy-custom-image example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ You can also enter an example directory directly and run its local `make setup` 
 |---|---|---|
 | `browser-agent` | Python + browser sandbox + LLM | Browser automation agent |
 | `custom-image-go-sdk` | Go | Custom-image / custom-tool startup |
+| `deploy-custom-image` | Python + Dockerfile + CCR | One-click deploy any Docker image as AGS custom tool |
 | `data-analysis` | Python + code sandbox | Multi-context data workflow |
 | `html-processing` | Python + browser/code sandboxes | Dual-sandbox HTML pipeline |
 | `hybrid-cookbook` | Go | Minimal control-plane + data-plane flow |

--- a/README_zh.md
+++ b/README_zh.md
@@ -68,6 +68,7 @@ make example-run EXAMPLE=mini-rl
 |---|---|---|
 | `browser-agent` | Python + 浏览器沙箱 + LLM | 浏览器自动化 Agent |
 | `custom-image-go-sdk` | Go | 自定义镜像 / 自定义工具启动 |
+| `deploy-custom-image` | Python + Dockerfile + CCR | 一键将任意 Docker 镜像部署为 AGS 自定义沙箱工具 |
 | `data-analysis` | Python + 代码沙箱 | 多 Context 数据分析 |
 | `html-processing` | Python + Browser/Code 双沙箱 | HTML 协作处理 |
 | `hybrid-cookbook` | Go | 最小控制面 + 数据面流程 |

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,7 @@ This directory contains runnable AGS examples. Each example keeps its own README
 - `mobile-use` — Android / Appium automation in AGS
 - `shop-assistant` — browser shopping-flow automation with optional cookies
 - `custom-image-go-sdk` — custom-image startup and data-plane execution in Go
+- `deploy-custom-image` — one-click deploy any Docker image as a custom AGS sandbox tool
 
 ### Heavy / external-dependent
 
@@ -38,6 +39,7 @@ Some heavier or externally overlaid examples are exceptions, but they should sti
 |---|---|---|---|---|
 | `browser-agent` | advanced | Python + browser sandbox + LLM | `make run` | Requires OpenAI-compatible LLM backend env vars |
 | `custom-image-go-sdk` | advanced | Go | `make run` | Requires custom tool/image setup in AGS account |
+| `deploy-custom-image` | advanced | Python + Dockerfile + CCR | `make run` | Requires CCR login and CAM role with pull permission |
 | `data-analysis` | advanced | Python + code sandbox | `make run` | Generates multiple output files |
 | `html-processing` | starter | Python + browser/code sandboxes | `make run` | Good visual intro to dual-sandbox flow |
 | `hybrid-cookbook` | starter | Go | `make run` | Minimal Go integration path |

--- a/examples/README_zh.md
+++ b/examples/README_zh.md
@@ -17,6 +17,7 @@
 - `mobile-use` —— 在 AGS 中运行 Android / Appium 自动化
 - `shop-assistant` —— 浏览器购物流程自动化，支持无 Cookie 的 guest 模式
 - `custom-image-go-sdk` —— Go 中的自定义镜像启动与数据面执行
+- `deploy-custom-image` —— 一键将任意 Docker 镜像部署为 AGS 自定义沙箱工具
 
 ### 重型 / 外部依赖
 
@@ -38,6 +39,7 @@
 |---|---|---|---|---|
 | `browser-agent` | 进阶 | Python + 浏览器沙箱 + LLM | `make run` | 需要 OpenAI-compatible LLM backend 环境变量 |
 | `custom-image-go-sdk` | 进阶 | Go | `make run` | 依赖 AGS 账号中的自定义工具 / 镜像配置 |
+| `deploy-custom-image` | 进阶 | Python + Dockerfile + CCR | `make run` | 需要 CCR 登录和有拉取权限的 CAM 角色 |
 | `data-analysis` | 进阶 | Python + 代码沙箱 | `make run` | 会生成多种图表与报告文件 |
 | `html-processing` | 入门 | Python + 浏览器/代码双沙箱 | `make run` | 适合作为双沙箱协作的直观起点 |
 | `hybrid-cookbook` | 入门 | Go | `make run` | 最小 Go 集成路径 |

--- a/examples/deploy-custom-image/.env.example
+++ b/examples/deploy-custom-image/.env.example
@@ -23,3 +23,6 @@ TOOL_MEMORY=8Gi
 
 # CAM role ARN (must trust AGS and have CCR pull permission)
 ROLE_ARN=qcs::cam::uin/xxx:roleName/your-role-name
+
+# CCR registry type: personal (default) or enterprise
+# REGISTRY_TYPE=personal

--- a/examples/deploy-custom-image/.env.example
+++ b/examples/deploy-custom-image/.env.example
@@ -1,0 +1,25 @@
+# Copy to .env and fill in real values
+
+# Source image to deploy into AGS
+SOURCE_IMAGE=ccr.ccs.tencentyun.com/ags-image/sandbox-browser:latest
+
+# Full target image path in Tencent Cloud CCR (must be logged in via podman/docker login)
+# The script appends :latest and :<hash> tags automatically
+TENCENTCLOUD_REGISTRY=ccr.ccs.tencentyun.com/your-namespace/your-image-name
+
+# Tencent Cloud credentials (for AGS control-plane API)
+TENCENTCLOUD_SECRET_ID=your_secret_id
+TENCENTCLOUD_SECRET_KEY=your_secret_key
+TENCENTCLOUD_REGION=ap-guangzhou
+
+# AGS configuration
+AGS_API_KEY=ark_your_api_key
+AGS_DOMAIN=ap-guangzhou.tencentags.com
+
+# Sandbox tool settings
+TOOL_NAME=my-custom-sandbox
+TOOL_CPU=4
+TOOL_MEMORY=8Gi
+
+# CAM role ARN (must trust AGS and have CCR pull permission)
+ROLE_ARN=qcs::cam::uin/xxx:roleName/your-role-name

--- a/examples/deploy-custom-image/.gitignore
+++ b/examples/deploy-custom-image/.gitignore
@@ -1,0 +1,4 @@
+.env
+.venv/
+__pycache__/
+*.pyc

--- a/examples/deploy-custom-image/Dockerfile
+++ b/examples/deploy-custom-image/Dockerfile
@@ -1,4 +1,5 @@
 ARG SOURCE_IMAGE
 
 FROM ${SOURCE_IMAGE}
+# Pin to a specific tag/digest when reproducibility is required
 COPY --from=ccr.ccs.tencentyun.com/ags-image/envd:latest --chmod=755 /usr/bin/envd /usr/bin/envd

--- a/examples/deploy-custom-image/Dockerfile
+++ b/examples/deploy-custom-image/Dockerfile
@@ -1,5 +1,4 @@
 ARG SOURCE_IMAGE
 
 FROM ${SOURCE_IMAGE}
-# Pin to a specific tag/digest when reproducibility is required
-COPY --from=ccr.ccs.tencentyun.com/ags-image/envd:latest --chmod=755 /usr/bin/envd /usr/bin/envd
+COPY --from=ccr.ccs.tencentyun.com/ags-image/envd@sha256:2fe2b8621485874d56216d898dbe8cb60ffa177691be7f8e18a7f906fcbc3851 --chmod=755 /usr/bin/envd /usr/bin/envd

--- a/examples/deploy-custom-image/Dockerfile
+++ b/examples/deploy-custom-image/Dockerfile
@@ -1,6 +1,4 @@
 ARG SOURCE_IMAGE
 
 FROM ${SOURCE_IMAGE}
-USER root
-COPY --from=ccr.ccs.tencentyun.com/ags-image/envd:latest /usr/bin/envd /usr/bin/envd
-RUN chmod +x /usr/bin/envd
+COPY --from=ccr.ccs.tencentyun.com/ags-image/envd:latest --chmod=755 /usr/bin/envd /usr/bin/envd

--- a/examples/deploy-custom-image/Dockerfile
+++ b/examples/deploy-custom-image/Dockerfile
@@ -1,0 +1,6 @@
+ARG SOURCE_IMAGE
+
+FROM ${SOURCE_IMAGE}
+USER root
+COPY --from=ccr.ccs.tencentyun.com/ags-image/envd:latest /usr/bin/envd /usr/bin/envd
+RUN chmod +x /usr/bin/envd

--- a/examples/deploy-custom-image/Makefile
+++ b/examples/deploy-custom-image/Makefile
@@ -1,0 +1,7 @@
+.PHONY: setup run
+
+setup:
+	uv sync
+
+run:
+	uv run main.py

--- a/examples/deploy-custom-image/README.md
+++ b/examples/deploy-custom-image/README.md
@@ -62,6 +62,8 @@ A successful run should:
 2. Create (or update) an AGS sandbox tool pointing to the pushed image
 3. Print the tool name and SDK usage examples for creating sandbox instances
 
+The printed usage example requires the [e2b AGS SDK](https://pypi.org/project/e2b-code-interpreter/) — install it separately via `pip install e2b-code-interpreter` if needed.
+
 ## Common failure hints
 
 - If `podman push` fails with auth errors, re-run `podman login ccr.ccs.tencentyun.com`

--- a/examples/deploy-custom-image/README.md
+++ b/examples/deploy-custom-image/README.md
@@ -1,0 +1,69 @@
+# deploy-custom-image
+
+One-click workflow to deploy any existing Docker image as a custom AGS sandbox tool: pull → build thin wrapper (inject envd) → push to Tencent Cloud CCR → create or update the AGS sandbox tool via the control-plane API.
+
+## Prerequisites
+
+- Python >= 3.11
+- `podman` or `docker` CLI, logged in to the target CCR registry
+- A Tencent Cloud CAM role that allows AGS to pull from the target registry
+- `TENCENTCLOUD_SECRET_ID` / `TENCENTCLOUD_SECRET_KEY`
+
+## Local commands
+
+```bash
+make setup
+make run
+```
+
+## Important environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `SOURCE_IMAGE` | yes | Docker image to deploy (e.g. `nginx:latest`, `ccr.ccs.tencentyun.com/ns/img:tag`) |
+| `TENCENTCLOUD_REGISTRY` | yes | Full target image path in CCR (e.g. `ccr.ccs.tencentyun.com/ns/my-image`) |
+| `TENCENTCLOUD_SECRET_ID` | yes | Tencent Cloud API credential |
+| `TENCENTCLOUD_SECRET_KEY` | yes | Tencent Cloud API credential |
+| `TENCENTCLOUD_REGION` | yes | Region (e.g. `ap-guangzhou`) |
+| `AGS_API_KEY` | yes | AGS API key for sandbox instances |
+| `AGS_DOMAIN` | yes | AGS endpoint domain |
+| `TOOL_NAME` | yes | Name for the sandbox tool to create/update |
+| `TOOL_CPU` | yes | CPU cores (e.g. `4`) |
+| `TOOL_MEMORY` | yes | Memory (e.g. `8Gi`) |
+| `ROLE_ARN` | yes | CAM role ARN with CCR pull permission |
+
+## How it works
+
+```
+SOURCE_IMAGE (any registry)
+        │
+        ▼
+┌───────────────────┐     podman/docker      ┌──────────────────────────┐
+│  Dockerfile       │ ──────────────────────▶ │  TENCENTCLOUD_REGISTRY   │
+│  (inject envd)    │     build + push        │  (full image path)       │
+└───────────────────┘                         └──────────────────────────┘
+                                                       │
+                              TencentCloud SDK         │
+                              CreateSandboxTool /      │
+                              UpdateSandboxTool        ▼
+                                              ┌─────────────────────┐
+                                              │  AGS Sandbox Tool   │
+                                              │  (ready to start)   │
+                                              └─────────────────────┘
+```
+
+The `Dockerfile` uses a multi-stage `COPY --from` to inject the `envd` binary from the official `ccr.ccs.tencentyun.com/ags-image/envd:latest` image into the source image. No other modifications are made to the original image.
+
+## Expected result
+
+A successful run should:
+
+1. Build a thin wrapper image (source image + envd) and push it to CCR with `:latest` and `:<hash>` tags
+2. Create (or update) an AGS sandbox tool pointing to the pushed image
+3. Print the tool name and SDK usage examples for creating sandbox instances
+
+## Common failure hints
+
+- If `podman push` fails with auth errors, re-run `podman login ccr.ccs.tencentyun.com`
+- If the control plane rejects the role ARN, verify the CAM role trusts the AGS service and has TCR/CCR pull permissions
+- If `UpdateSandboxTool` fails, ensure the tool was initially created by the same account

--- a/examples/deploy-custom-image/README.md
+++ b/examples/deploy-custom-image/README.md
@@ -5,7 +5,7 @@ One-click workflow to deploy any existing Docker image as a custom AGS sandbox t
 ## Prerequisites
 
 - Python >= 3.11
-- `podman` or `docker` CLI, logged in to the target CCR registry
+- `podman` or `docker` CLI, logged in to the target registry — see [CCR Quick Start](https://cloud.tencent.com/document/product/1141/63910) or [TCR Quick Start](https://cloud.tencent.com/document/product/1141/39287)
 - A Tencent Cloud CAM role that allows AGS to pull from the target registry
 - `TENCENTCLOUD_SECRET_ID` / `TENCENTCLOUD_SECRET_KEY`
 

--- a/examples/deploy-custom-image/README.md
+++ b/examples/deploy-custom-image/README.md
@@ -52,7 +52,7 @@ SOURCE_IMAGE (any registry)
                                               └─────────────────────┘
 ```
 
-The `Dockerfile` uses a multi-stage `COPY --from` to inject the `envd` binary from the official `ccr.ccs.tencentyun.com/ags-image/envd:latest` image into the source image. No other modifications are made to the original image.
+The `Dockerfile` uses `COPY --from` to inject the `envd` binary from a pinned digest of `ccr.ccs.tencentyun.com/ags-image/envd` (see `Dockerfile` for the exact digest). No other modifications are made to the original image.
 
 ## Expected result
 

--- a/examples/deploy-custom-image/README_zh.md
+++ b/examples/deploy-custom-image/README_zh.md
@@ -1,0 +1,43 @@
+# deploy-custom-image
+
+一键将现有 Docker 镜像部署为 AGS 自定义沙箱工具：拉取镜像 → 构建薄包装（注入 envd）→ 推送到腾讯云 CCR → 通过控制面 API 创建或更新沙箱工具。
+
+## 前置条件
+
+- Python >= 3.11
+- `podman` 或 `docker` CLI，已登录目标 CCR 仓库
+- 一个允许 AGS 从目标仓库拉取镜像的 CAM 角色
+- `TENCENTCLOUD_SECRET_ID` / `TENCENTCLOUD_SECRET_KEY`
+
+## 快速开始
+
+```bash
+make setup
+make run
+```
+
+## 环境变量
+
+| 变量 | 必填 | 说明 |
+|---|---|---|
+| `SOURCE_IMAGE` | 是 | 要部署的 Docker 镜像（如 `nginx:latest`） |
+| `TENCENTCLOUD_REGISTRY` | 是 | CCR 完整镜像路径（如 `ccr.ccs.tencentyun.com/ns/my-image`） |
+| `TENCENTCLOUD_SECRET_ID` | 是 | 腾讯云 API 凭据 |
+| `TENCENTCLOUD_SECRET_KEY` | 是 | 腾讯云 API 凭据 |
+| `TENCENTCLOUD_REGION` | 是 | 地域（如 `ap-guangzhou`） |
+| `AGS_API_KEY` | 是 | AGS API Key |
+| `AGS_DOMAIN` | 是 | AGS 端点域名 |
+| `TOOL_NAME` | 是 | 要创建/更新的沙箱工具名称 |
+| `TOOL_CPU` | 是 | CPU 核数（如 `4`） |
+| `TOOL_MEMORY` | 是 | 内存（如 `8Gi`） |
+| `ROLE_ARN` | 是 | 有 CCR 拉取权限的 CAM 角色 ARN |
+
+## 工作原理
+
+`Dockerfile` 通过多阶段构建，从官方 `ccr.ccs.tencentyun.com/ags-image/envd:latest` 镜像中提取 `envd` 二进制并注入到源镜像中，不做任何其他修改。
+
+## 预期结果
+
+1. 构建薄包装镜像（源镜像 + envd）并推送到 CCR（`:latest` 和 `:<hash>` 两个标签）
+2. 创建（或更新）指向该镜像的 AGS 沙箱工具
+3. 输出工具名称和创建沙箱实例的 SDK 使用示例

--- a/examples/deploy-custom-image/README_zh.md
+++ b/examples/deploy-custom-image/README_zh.md
@@ -34,7 +34,7 @@ make run
 
 ## 工作原理
 
-`Dockerfile` 通过多阶段构建，从官方 `ccr.ccs.tencentyun.com/ags-image/envd:latest` 镜像中提取 `envd` 二进制并注入到源镜像中，不做任何其他修改。
+`Dockerfile` 通过 `COPY --from` 从固定 digest 的 `ccr.ccs.tencentyun.com/ags-image/envd` 镜像中提取 `envd` 二进制并注入到源镜像中（具体 digest 见 `Dockerfile`），不做任何其他修改。
 
 ## 预期结果
 
@@ -43,3 +43,9 @@ make run
 3. 输出工具名称和创建沙箱实例的 SDK 使用示例
 
 输出的使用示例需要 [e2b AGS SDK](https://pypi.org/project/e2b-code-interpreter/)，按需安装：`pip install e2b-code-interpreter`。
+
+## 常见失败排查
+
+- 如果 `podman push` 报认证错误，重新执行 `podman login ccr.ccs.tencentyun.com`
+- 如果控制面拒绝角色 ARN，检查 CAM 角色是否信任 AGS 服务并具有 TCR/CCR 拉取权限
+- 如果 `UpdateSandboxTool` 失败，确认工具最初是否由同一账号创建

--- a/examples/deploy-custom-image/README_zh.md
+++ b/examples/deploy-custom-image/README_zh.md
@@ -41,3 +41,5 @@ make run
 1. 构建薄包装镜像（源镜像 + envd）并推送到 CCR（`:latest` 和 `:<hash>` 两个标签）
 2. 创建（或更新）指向该镜像的 AGS 沙箱工具
 3. 输出工具名称和创建沙箱实例的 SDK 使用示例
+
+输出的使用示例需要 [e2b AGS SDK](https://pypi.org/project/e2b-code-interpreter/)，按需安装：`pip install e2b-code-interpreter`。

--- a/examples/deploy-custom-image/README_zh.md
+++ b/examples/deploy-custom-image/README_zh.md
@@ -5,7 +5,7 @@
 ## 前置条件
 
 - Python >= 3.11
-- `podman` 或 `docker` CLI，已登录目标 CCR 仓库
+- `podman` 或 `docker` CLI，已登录目标镜像仓库 — 参考 [CCR 个人版快速入门](https://cloud.tencent.com/document/product/1141/63910) 或 [TCR 企业版快速入门](https://cloud.tencent.com/document/product/1141/39287)
 - 一个允许 AGS 从目标仓库拉取镜像的 CAM 角色
 - `TENCENTCLOUD_SECRET_ID` / `TENCENTCLOUD_SECRET_KEY`
 

--- a/examples/deploy-custom-image/main.py
+++ b/examples/deploy-custom-image/main.py
@@ -86,6 +86,11 @@ def build_and_push(cfg: dict[str, str], engine: str) -> tuple[str, dict]:
     target = cfg["TENCENTCLOUD_REGISTRY"].rstrip("/")
     image_latest = f"{target}:latest"
 
+    run([engine, "pull", "--platform", "linux/amd64", source_image])
+
+    print(f"\n  Inspecting source image: {source_image}")
+    image_info = inspect_source_image(engine, source_image)
+
     run([
         engine, "build",
         "--platform", "linux/amd64",
@@ -93,9 +98,6 @@ def build_and_push(cfg: dict[str, str], engine: str) -> tuple[str, dict]:
         "-t", image_latest,
         str(SCRIPT_DIR),
     ])
-
-    print(f"\n  Inspecting source image: {source_image}")
-    image_info = inspect_source_image(engine, source_image)
 
     result = subprocess.run(
         [engine, "inspect", "--format={{.Id}}", image_latest],

--- a/examples/deploy-custom-image/main.py
+++ b/examples/deploy-custom-image/main.py
@@ -72,7 +72,9 @@ def load_config() -> dict[str, str]:
             print(f"  - {var}")
         die("Edit .env to fill in the missing values.")
 
-    return {v: os.environ[v] for v in REQUIRED_VARS}
+    cfg = {v: os.environ[v] for v in REQUIRED_VARS}
+    cfg["REGISTRY_TYPE"] = os.environ.get("REGISTRY_TYPE", "personal")
+    return cfg
 
 
 # ---------------------------------------------------------------------------
@@ -171,11 +173,9 @@ def inspect_source_image(engine: str, source_image: str) -> dict:
 
 def build_custom_config(cfg: dict[str, str], image_ref: str, image_info: dict, models):
     """Build the CustomConfiguration from image inspection results."""
-    registry_type = os.environ.get("REGISTRY_TYPE", "personal")
-
     cc = models.CustomConfiguration()
     cc.Image = image_ref
-    cc.ImageRegistryType = registry_type
+    cc.ImageRegistryType = cfg["REGISTRY_TYPE"]
 
     entrypoint = image_info["entrypoint"]
     cmd = image_info["cmd"]
@@ -359,7 +359,7 @@ def main() -> None:
         print_summary(cfg, image_ref, image_info)
     except subprocess.CalledProcessError as exc:
         die(f"Command failed: {exc.cmd}\n       Return code: {exc.returncode}")
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001 — surface SDK errors uniformly
         code = getattr(exc, "code", None) or type(exc).__name__
         message = getattr(exc, "message", None) or str(exc)
         die(f"API error [{code}]: {message}")

--- a/examples/deploy-custom-image/main.py
+++ b/examples/deploy-custom-image/main.py
@@ -136,7 +136,10 @@ def inspect_source_image(engine: str, source_image: str) -> dict:
     config_raw = result.stdout.strip()
     config = json.loads(config_raw) if config_raw and config_raw != "null" else {}
     if not config:
-        print("  Warning: could not read image config, proceeding with defaults")
+        die(
+            f"Could not read image config for '{source_image}'.\n"
+            f"       Ensure the image exists and was pulled successfully."
+        )
 
     entrypoint = config.get("Entrypoint") or []
     cmd = config.get("Cmd") or []
@@ -181,6 +184,8 @@ def build_custom_config(cfg: dict[str, str], image_ref: str, image_info: dict, m
     cmd = image_info["cmd"]
     original_parts = entrypoint + cmd
     if original_parts:
+        # shlex.quote handles each arg; AGS passes Args as-is without re-interpolation.
+        # The user trusts the source image they chose to deploy.
         original_cmd = " ".join(shlex.quote(p) for p in original_parts)
         cc.Command = ["/bin/sh"]
         cc.Args = ["-c", f"/usr/bin/envd & exec {original_cmd}"]

--- a/examples/deploy-custom-image/main.py
+++ b/examples/deploy-custom-image/main.py
@@ -190,6 +190,8 @@ def build_custom_config(cfg: dict[str, str], image_ref: str, image_info: dict, m
         cc.Command = ["/bin/sh"]
         cc.Args = ["-c", f"/usr/bin/envd & exec {original_cmd}"]
     else:
+        print("  \033[33mWarning: source image has no ENTRYPOINT or CMD.\033[0m")
+        print("  \033[33m  The sandbox will only run envd — no application process.\033[0m")
         cc.Command = ["/usr/bin/envd"]
 
     res = models.ResourceConfiguration()

--- a/examples/deploy-custom-image/main.py
+++ b/examples/deploy-custom-image/main.py
@@ -255,7 +255,7 @@ def find_tool_by_name(client, models, tool_name: str):
             if t.ToolName == tool_name:
                 return t
         offset += len(tools)
-        if not tools or offset >= resp.TotalCount:
+        if not tools or offset >= (resp.TotalCount or 0):
             return None
     return None
 

--- a/examples/deploy-custom-image/main.py
+++ b/examples/deploy-custom-image/main.py
@@ -86,6 +86,7 @@ def build_and_push(cfg: dict[str, str], engine: str) -> tuple[str, dict]:
     target = cfg["TENCENTCLOUD_REGISTRY"].rstrip("/")
     image_latest = f"{target}:latest"
 
+    # AGS runs linux/amd64 only; source image must provide an amd64 manifest
     run([engine, "pull", "--platform", "linux/amd64", source_image])
 
     print(f"\n  Inspecting source image: {source_image}")
@@ -130,7 +131,10 @@ def inspect_source_image(engine: str, source_image: str) -> dict:
         [engine, "inspect", "--format={{json .Config}}", source_image],
         check=True, capture_output=True, text=True,
     )
-    config = json.loads(result.stdout.strip())
+    config_raw = result.stdout.strip()
+    config = json.loads(config_raw) if config_raw and config_raw != "null" else {}
+    if not config:
+        print("  Warning: could not read image config, proceeding with defaults")
 
     entrypoint = config.get("Entrypoint") or []
     cmd = config.get("Cmd") or []
@@ -217,6 +221,9 @@ def build_custom_config(cfg: dict[str, str], image_ref: str, image_info: dict, m
             probe_port = int(m.group(1))
             probe_path = m.group(2) or "/"
             print(f"  Using image healthcheck: port={probe_port}, path={probe_path}")
+        else:
+            print(f"  Warning: cannot parse healthcheck command: {test_str!r}")
+            print(f"  Falling back to envd probe (port {ENVD_PORT}, path /health)")
 
     http_get = models.HttpGetAction()
     http_get.Scheme = "HTTP"
@@ -305,8 +312,9 @@ def print_summary(cfg: dict[str, str], image_ref: str, image_info: dict) -> None
     tool_name = cfg["TOOL_NAME"]
     domain = cfg["AGS_DOMAIN"]
 
-    image_ports = image_info["ports"]
-    port_list = ", ".join(str(p) for p, _ in sorted(image_ports))
+    # Only show application ports; ENVD_PORT (49983) is internal and not printed
+    app_ports = [(p, t) for p, t in image_info["ports"] if p != ENVD_PORT]
+    port_list = ", ".join(str(p) for p, _ in sorted(app_ports)) or "(none)"
 
     print(f"\n  Tool Name : {tool_name}")
     print(f"  Image     : {image_ref}")
@@ -314,13 +322,17 @@ def print_summary(cfg: dict[str, str], image_ref: str, image_info: dict) -> None
     print(f"  Region    : {cfg['TENCENTCLOUD_REGION']}")
     print(f"  Ports     : {port_list}")
     print()
+    # e2b_code_interpreter is the AGS-compatible Python SDK for creating sandbox instances.
+    # Install separately: pip install e2b-code-interpreter
     print("  \033[1;33mTo create a sandbox instance (Python):\033[0m")
     print()
-    print('  \033[90mfrom e2b_code_interpreter import Sandbox')
+    print('  \033[90mfrom e2b_code_interpreter import Sandbox  # pip install e2b-code-interpreter')
     print()
     print(f'  sandbox = Sandbox.create(template="{tool_name}", api_key="<YOUR_AGS_API_KEY>", domain="{domain}")')
+    # _envd_access_token is the only way to obtain the gateway access token;
+    # no public API is available in the current SDK version.
     print('  token = sandbox._envd_access_token')
-    for port_num, _ in sorted(image_ports):
+    for port_num, _ in sorted(app_ports):
         print(f'  print(f"port {port_num}: https://{{sandbox.get_host({port_num})}}/?" + f"access_token={{token}}")')
     print('\033[0m')
 

--- a/examples/deploy-custom-image/main.py
+++ b/examples/deploy-custom-image/main.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
+ENVD_PORT = 49983
+MAX_LIST_PAGES = 50
 
 REQUIRED_VARS = [
     "SOURCE_IMAGE",
@@ -56,9 +58,9 @@ def load_config() -> dict[str, str]:
     env_file = SCRIPT_DIR / ".env"
     if not env_file.exists():
         die(
-            f"No .env found. Create one first:\n"
-            f"       cp .env.example .env\n"
-            f"       # then edit with your values"
+            "No .env found. Create one first:\n"
+            "       cp .env.example .env\n"
+            "       # then edit with your values"
         )
 
     load_dotenv(env_file)
@@ -68,7 +70,7 @@ def load_config() -> dict[str, str]:
         print("\033[1;31mMissing required environment variables:\033[0m")
         for var in missing:
             print(f"  - {var}")
-        die(f"Edit .env to fill in the missing values.")
+        die("Edit .env to fill in the missing values.")
 
     return {v: os.environ[v] for v in REQUIRED_VARS}
 
@@ -120,8 +122,6 @@ def build_and_push(cfg: dict[str, str], engine: str) -> tuple[str, dict]:
 # Image inspection
 # ---------------------------------------------------------------------------
 
-ENVD_PORT = 49983
-
 def inspect_source_image(engine: str, source_image: str) -> dict:
     """Extract CMD, ENTRYPOINT, ExposedPorts, and Healthcheck from the source image."""
     result = subprocess.run(
@@ -137,8 +137,14 @@ def inspect_source_image(engine: str, source_image: str) -> dict:
 
     ports: list[tuple[int, str]] = []
     for port_spec in exposed_ports:
-        num_str, proto = port_spec.split("/")
-        ports.append((int(num_str), proto.upper()))
+        parts = port_spec.split("/")
+        if len(parts) != 2:
+            print(f"  Warning: skipping unexpected port spec: {port_spec!r}")
+            continue
+        try:
+            ports.append((int(parts[0]), parts[1].upper()))
+        except ValueError:
+            print(f"  Warning: skipping invalid port number: {parts[0]!r}")
 
     print(f"  Entrypoint : {entrypoint or '(none)'}")
     print(f"  Cmd        : {cmd or '(none)'}")
@@ -159,9 +165,11 @@ def inspect_source_image(engine: str, source_image: str) -> dict:
 
 def build_custom_config(cfg: dict[str, str], image_ref: str, image_info: dict, models):
     """Build the CustomConfiguration from image inspection results."""
+    registry_type = os.environ.get("REGISTRY_TYPE", "personal")
+
     cc = models.CustomConfiguration()
     cc.Image = image_ref
-    cc.ImageRegistryType = "personal"
+    cc.ImageRegistryType = registry_type
 
     entrypoint = image_info["entrypoint"]
     cmd = image_info["cmd"]
@@ -178,7 +186,6 @@ def build_custom_config(cfg: dict[str, str], image_ref: str, image_info: dict, m
     res.Memory = cfg["TOOL_MEMORY"]
     cc.Resources = res
 
-    # Ports: source image exposed ports + envd port
     image_ports = list(image_info["ports"])
     port_nums = {p for p, _ in image_ports}
     if ENVD_PORT not in port_nums:
@@ -193,18 +200,17 @@ def build_custom_config(cfg: dict[str, str], image_ref: str, image_info: dict, m
         port_configs.append(pc)
     cc.Ports = port_configs
 
-    # Probe: use image HEALTHCHECK if it defines an HTTP-style check,
-    # otherwise fall back to envd /health on port 49983
     healthcheck = image_info["healthcheck"]
     probe_port = ENVD_PORT
     probe_path = "/health"
 
     if healthcheck and healthcheck.get("Test"):
         test_cmd = healthcheck["Test"]
-        # Docker HEALTHCHECK format: ["CMD-SHELL", "curl ..."] or ["CMD", "curl", ...]
         test_str = test_cmd[-1] if test_cmd else ""
-        # Try to extract port from curl/wget commands like "curl http://localhost:8080/health"
-        m = re.search(r"https?://(?:localhost|127\.0\.0\.1):(\d+)(/\S*)?", test_str)
+        m = re.search(
+            r"https?://(?:localhost|127\.0\.0\.1|0\.0\.0\.0):(\d+)(/\S*)?",
+            test_str,
+        )
         if m:
             probe_port = int(m.group(1))
             probe_path = m.group(2) or "/"
@@ -230,7 +236,7 @@ def build_custom_config(cfg: dict[str, str], image_ref: str, image_info: dict, m
 def find_tool_by_name(client, models, tool_name: str):
     """Paginate through all tools and find by exact ToolName match."""
     offset = 0
-    while True:
+    for _ in range(MAX_LIST_PAGES):
         req = models.DescribeSandboxToolListRequest()
         req.Limit = 100
         req.Offset = offset
@@ -242,6 +248,7 @@ def find_tool_by_name(client, models, tool_name: str):
         offset += len(tools)
         if not tools or offset >= resp.TotalCount:
             return None
+    return None
 
 
 def ags_create_or_update(cfg: dict[str, str], image_ref: str, image_info: dict) -> None:
@@ -295,7 +302,6 @@ def print_summary(cfg: dict[str, str], image_ref: str, image_info: dict) -> None
 
     tool_name = cfg["TOOL_NAME"]
     domain = cfg["AGS_DOMAIN"]
-    api_key = cfg["AGS_API_KEY"]
 
     image_ports = image_info["ports"]
     port_list = ", ".join(str(p) for p, _ in sorted(image_ports))
@@ -308,13 +314,13 @@ def print_summary(cfg: dict[str, str], image_ref: str, image_info: dict) -> None
     print()
     print("  \033[1;33mTo create a sandbox instance (Python):\033[0m")
     print()
-    print(f'  \033[90mfrom e2b_code_interpreter import Sandbox')
+    print('  \033[90mfrom e2b_code_interpreter import Sandbox')
     print()
-    print(f'  sandbox = Sandbox.create(template="{tool_name}", api_key="{api_key}", domain="{domain}")')
-    print(f'  token = sandbox._envd_access_token')
+    print(f'  sandbox = Sandbox.create(template="{tool_name}", api_key="<YOUR_AGS_API_KEY>", domain="{domain}")')
+    print('  token = sandbox._envd_access_token')
     for port_num, _ in sorted(image_ports):
         print(f'  print(f"port {port_num}: https://{{sandbox.get_host({port_num})}}/?" + f"access_token={{token}}")')
-    print(f'\033[0m')
+    print('\033[0m')
 
 
 # ---------------------------------------------------------------------------
@@ -341,6 +347,10 @@ def main() -> None:
         print_summary(cfg, image_ref, image_info)
     except subprocess.CalledProcessError as exc:
         die(f"Command failed: {exc.cmd}\n       Return code: {exc.returncode}")
+    except Exception as exc:  # noqa: BLE001
+        code = getattr(exc, "code", None) or type(exc).__name__
+        message = getattr(exc, "message", None) or str(exc)
+        die(f"API error [{code}]: {message}")
 
     print("\033[1;32m✅  All done!\033[0m")
 

--- a/examples/deploy-custom-image/main.py
+++ b/examples/deploy-custom-image/main.py
@@ -329,9 +329,7 @@ def print_summary(cfg: dict[str, str], image_ref: str, image_info: dict) -> None
     print('  \033[90mfrom e2b_code_interpreter import Sandbox  # pip install e2b-code-interpreter')
     print()
     print(f'  sandbox = Sandbox.create(template="{tool_name}", api_key="<YOUR_AGS_API_KEY>", domain="{domain}")')
-    # _envd_access_token is the only way to obtain the gateway access token;
-    # no public API is available in the current SDK version.
-    print('  token = sandbox._envd_access_token')
+    print('  token = sandbox._envd_access_token  # NOTE: private API, no public alternative yet')
     for port_num, _ in sorted(app_ports):
         print(f'  print(f"port {port_num}: https://{{sandbox.get_host({port_num})}}/?" + f"access_token={{token}}")')
     print('\033[0m')

--- a/examples/deploy-custom-image/main.py
+++ b/examples/deploy-custom-image/main.py
@@ -1,0 +1,349 @@
+"""
+One-click deploy: pull image → build wrapper (inject envd) → push to CCR → create/update AGS sandbox tool.
+"""
+
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+
+REQUIRED_VARS = [
+    "SOURCE_IMAGE",
+    "TENCENTCLOUD_REGISTRY",
+    "TENCENTCLOUD_SECRET_ID",
+    "TENCENTCLOUD_SECRET_KEY",
+    "TENCENTCLOUD_REGION",
+    "AGS_API_KEY",
+    "AGS_DOMAIN",
+    "TOOL_NAME",
+    "TOOL_CPU",
+    "TOOL_MEMORY",
+    "ROLE_ARN",
+]
+
+
+def step(n: int, total: int, msg: str) -> None:
+    print(f"\n\033[1;36m[{n}/{total}] {msg}\033[0m")
+
+
+def die(msg: str, code: int = 1) -> None:
+    print(f"\033[1;31mERROR: {msg}\033[0m", file=sys.stderr)
+    sys.exit(code)
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    print(f"  \033[90m$ {shlex.join(cmd)}\033[0m")
+    return subprocess.run(cmd, check=True, **kwargs)
+
+
+def detect_container_engine() -> str:
+    for engine in ["podman", "docker"]:
+        if shutil.which(engine):
+            return engine
+    die("Neither 'podman' nor 'docker' found in PATH. Install one and re-run.")
+    return ""
+
+
+def load_config() -> dict[str, str]:
+    env_file = SCRIPT_DIR / ".env"
+    if not env_file.exists():
+        die(
+            f"No .env found. Create one first:\n"
+            f"       cp .env.example .env\n"
+            f"       # then edit with your values"
+        )
+
+    load_dotenv(env_file)
+
+    missing = [v for v in REQUIRED_VARS if not os.environ.get(v)]
+    if missing:
+        print("\033[1;31mMissing required environment variables:\033[0m")
+        for var in missing:
+            print(f"  - {var}")
+        die(f"Edit .env to fill in the missing values.")
+
+    return {v: os.environ[v] for v in REQUIRED_VARS}
+
+
+# ---------------------------------------------------------------------------
+# Step 1: Build wrapper image & push to CCR
+# ---------------------------------------------------------------------------
+
+def build_and_push(cfg: dict[str, str], engine: str) -> tuple[str, dict]:
+    step(1, 3, "Build wrapper image & push to CCR")
+
+    source_image = cfg["SOURCE_IMAGE"]
+    target = cfg["TENCENTCLOUD_REGISTRY"].rstrip("/")
+    image_latest = f"{target}:latest"
+
+    run([
+        engine, "build",
+        "--platform", "linux/amd64",
+        "--build-arg", f"SOURCE_IMAGE={source_image}",
+        "-t", image_latest,
+        str(SCRIPT_DIR),
+    ])
+
+    print(f"\n  Inspecting source image: {source_image}")
+    image_info = inspect_source_image(engine, source_image)
+
+    result = subprocess.run(
+        [engine, "inspect", "--format={{.Id}}", image_latest],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    raw_id = result.stdout.strip()
+    raw_hash = raw_id.replace("sha256:", "")[:12]
+    image_hash_tag = f"{target}:{raw_hash}"
+
+    print(f"\n  Image hash: {raw_hash}")
+
+    run([engine, "tag", image_latest, image_hash_tag])
+    run([engine, "push", image_latest])
+    run([engine, "push", image_hash_tag])
+
+    print(f"  \033[32m✓ Pushed: {image_latest}\033[0m")
+    print(f"  \033[32m✓ Pushed: {image_hash_tag}\033[0m")
+    return image_hash_tag, image_info
+
+
+# ---------------------------------------------------------------------------
+# Image inspection
+# ---------------------------------------------------------------------------
+
+ENVD_PORT = 49983
+
+def inspect_source_image(engine: str, source_image: str) -> dict:
+    """Extract CMD, ENTRYPOINT, ExposedPorts, and Healthcheck from the source image."""
+    result = subprocess.run(
+        [engine, "inspect", "--format={{json .Config}}", source_image],
+        check=True, capture_output=True, text=True,
+    )
+    config = json.loads(result.stdout.strip())
+
+    entrypoint = config.get("Entrypoint") or []
+    cmd = config.get("Cmd") or []
+    exposed_ports = config.get("ExposedPorts") or {}
+    healthcheck = config.get("Healthcheck")
+
+    ports: list[tuple[int, str]] = []
+    for port_spec in exposed_ports:
+        num_str, proto = port_spec.split("/")
+        ports.append((int(num_str), proto.upper()))
+
+    print(f"  Entrypoint : {entrypoint or '(none)'}")
+    print(f"  Cmd        : {cmd or '(none)'}")
+    print(f"  Ports      : {[f'{p}/{t.lower()}' for p, t in ports] or '(none)'}")
+    print(f"  Healthcheck: {'yes' if healthcheck else 'no'}")
+
+    return {
+        "entrypoint": entrypoint,
+        "cmd": cmd,
+        "ports": ports,
+        "healthcheck": healthcheck,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Step 2: Create / Update AGS Sandbox Tool
+# ---------------------------------------------------------------------------
+
+def build_custom_config(cfg: dict[str, str], image_ref: str, image_info: dict, models):
+    """Build the CustomConfiguration from image inspection results."""
+    cc = models.CustomConfiguration()
+    cc.Image = image_ref
+    cc.ImageRegistryType = "personal"
+
+    entrypoint = image_info["entrypoint"]
+    cmd = image_info["cmd"]
+    original_parts = entrypoint + cmd
+    if original_parts:
+        original_cmd = " ".join(shlex.quote(p) for p in original_parts)
+        cc.Command = ["/bin/sh"]
+        cc.Args = ["-c", f"/usr/bin/envd & exec {original_cmd}"]
+    else:
+        cc.Command = ["/usr/bin/envd"]
+
+    res = models.ResourceConfiguration()
+    res.CPU = cfg["TOOL_CPU"]
+    res.Memory = cfg["TOOL_MEMORY"]
+    cc.Resources = res
+
+    # Ports: source image exposed ports + envd port
+    image_ports = list(image_info["ports"])
+    port_nums = {p for p, _ in image_ports}
+    if ENVD_PORT not in port_nums:
+        image_ports.append((ENVD_PORT, "TCP"))
+
+    port_configs = []
+    for port_num, proto in sorted(image_ports):
+        pc = models.PortConfiguration()
+        pc.Name = f"port-{port_num}"
+        pc.Protocol = proto
+        pc.Port = port_num
+        port_configs.append(pc)
+    cc.Ports = port_configs
+
+    # Probe: use image HEALTHCHECK if it defines an HTTP-style check,
+    # otherwise fall back to envd /health on port 49983
+    healthcheck = image_info["healthcheck"]
+    probe_port = ENVD_PORT
+    probe_path = "/health"
+
+    if healthcheck and healthcheck.get("Test"):
+        test_cmd = healthcheck["Test"]
+        # Docker HEALTHCHECK format: ["CMD-SHELL", "curl ..."] or ["CMD", "curl", ...]
+        test_str = test_cmd[-1] if test_cmd else ""
+        # Try to extract port from curl/wget commands like "curl http://localhost:8080/health"
+        m = re.search(r"https?://(?:localhost|127\.0\.0\.1):(\d+)(/\S*)?", test_str)
+        if m:
+            probe_port = int(m.group(1))
+            probe_path = m.group(2) or "/"
+            print(f"  Using image healthcheck: port={probe_port}, path={probe_path}")
+
+    http_get = models.HttpGetAction()
+    http_get.Scheme = "HTTP"
+    http_get.Port = probe_port
+    http_get.Path = probe_path
+
+    probe = models.ProbeConfiguration()
+    probe.HttpGet = http_get
+    probe.ReadyTimeoutMs = 30000
+    probe.ProbeTimeoutMs = 3000
+    probe.ProbePeriodMs = 3000
+    probe.FailureThreshold = 100
+    probe.SuccessThreshold = 1
+    cc.Probe = probe
+
+    return cc
+
+
+def find_tool_by_name(client, models, tool_name: str):
+    """Paginate through all tools and find by exact ToolName match."""
+    offset = 0
+    while True:
+        req = models.DescribeSandboxToolListRequest()
+        req.Limit = 100
+        req.Offset = offset
+        resp = client.DescribeSandboxToolList(req)
+        tools = resp.SandboxToolSet or []
+        for t in tools:
+            if t.ToolName == tool_name:
+                return t
+        offset += len(tools)
+        if not tools or offset >= resp.TotalCount:
+            return None
+
+
+def ags_create_or_update(cfg: dict[str, str], image_ref: str, image_info: dict) -> None:
+    step(2, 3, "Create / Update AGS Sandbox Tool")
+
+    from tencentcloud.common import credential
+    from tencentcloud.ags.v20250920 import ags_client, models
+
+    cred = credential.Credential(
+        cfg["TENCENTCLOUD_SECRET_ID"],
+        cfg["TENCENTCLOUD_SECRET_KEY"],
+    )
+    client = ags_client.AgsClient(cred, cfg["TENCENTCLOUD_REGION"])
+
+    tool_name = cfg["TOOL_NAME"]
+    print(f"  Searching for tool '{tool_name}' ...")
+    existing = find_tool_by_name(client, models, tool_name)
+
+    cc = build_custom_config(cfg, image_ref, image_info, models)
+
+    net = models.NetworkConfiguration()
+    net.NetworkMode = "PUBLIC"
+
+    if not existing:
+        print(f"  Tool '{tool_name}' not found -> Creating ...")
+        req = models.CreateSandboxToolRequest()
+        req.ToolName = tool_name
+        req.ToolType = "custom"
+        req.CustomConfiguration = cc
+        req.RoleArn = cfg["ROLE_ARN"]
+        req.NetworkConfiguration = net
+        client.CreateSandboxTool(req)
+        print(f"  \033[32m✓ Created tool: {tool_name}\033[0m")
+    else:
+        tool_id = existing.ToolId
+        print(f"  Tool '{tool_name}' exists (ID: {tool_id}) -> Updating image ...")
+        req = models.UpdateSandboxToolRequest()
+        req.ToolId = tool_id
+        req.CustomConfiguration = cc
+        req.NetworkConfiguration = net
+        client.UpdateSandboxTool(req)
+        print(f"  \033[32m✓ Updated tool: {tool_name} -> {image_ref}\033[0m")
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Print summary
+# ---------------------------------------------------------------------------
+
+def print_summary(cfg: dict[str, str], image_ref: str, image_info: dict) -> None:
+    step(3, 3, "Done! Summary")
+
+    tool_name = cfg["TOOL_NAME"]
+    domain = cfg["AGS_DOMAIN"]
+    api_key = cfg["AGS_API_KEY"]
+
+    image_ports = image_info["ports"]
+    port_list = ", ".join(str(p) for p, _ in sorted(image_ports))
+
+    print(f"\n  Tool Name : {tool_name}")
+    print(f"  Image     : {image_ref}")
+    print(f"  Domain    : {domain}")
+    print(f"  Region    : {cfg['TENCENTCLOUD_REGION']}")
+    print(f"  Ports     : {port_list}")
+    print()
+    print("  \033[1;33mTo create a sandbox instance (Python):\033[0m")
+    print()
+    print(f'  \033[90mfrom e2b_code_interpreter import Sandbox')
+    print()
+    print(f'  sandbox = Sandbox.create(template="{tool_name}", api_key="{api_key}", domain="{domain}")')
+    print(f'  token = sandbox._envd_access_token')
+    for port_num, _ in sorted(image_ports):
+        print(f'  print(f"port {port_num}: https://{{sandbox.get_host({port_num})}}/?" + f"access_token={{token}}")')
+    print(f'\033[0m')
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    print("\033[1;35m╔═══════════════════════════════════════════════╗\033[0m")
+    print("\033[1;35m║  AGS Custom Image  ·  One-click Deployment    ║\033[0m")
+    print("\033[1;35m╚═══════════════════════════════════════════════╝\033[0m")
+
+    engine = detect_container_engine()
+    cfg = load_config()
+
+    print(f"\n  Engine   : {engine}")
+    print(f"  Source   : {cfg['SOURCE_IMAGE']}")
+    print(f"  Target   : {cfg['TENCENTCLOUD_REGISTRY']}")
+    print(f"  Tool     : {cfg['TOOL_NAME']}")
+    print(f"  Region   : {cfg['TENCENTCLOUD_REGION']}")
+
+    try:
+        image_ref, image_info = build_and_push(cfg, engine)
+        ags_create_or_update(cfg, image_ref, image_info)
+        print_summary(cfg, image_ref, image_info)
+    except subprocess.CalledProcessError as exc:
+        die(f"Command failed: {exc.cmd}\n       Return code: {exc.returncode}")
+
+    print("\033[1;32m✅  All done!\033[0m")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/deploy-custom-image/pyproject.toml
+++ b/examples/deploy-custom-image/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "deploy-custom-image"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "tencentcloud-sdk-python-ags",
+    "python-dotenv",
+]

--- a/examples/deploy-custom-image/pyproject.toml
+++ b/examples/deploy-custom-image/pyproject.toml
@@ -3,6 +3,6 @@ name = "deploy-custom-image"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-    "tencentcloud-sdk-python-ags",
-    "python-dotenv",
+    "tencentcloud-sdk-python-ags>=3.1.59",
+    "python-dotenv>=1.0.0",
 ]

--- a/examples/deploy-custom-image/uv.lock
+++ b/examples/deploy-custom-image/uv.lock
@@ -111,8 +111,8 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "python-dotenv" },
-    { name = "tencentcloud-sdk-python-ags" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "tencentcloud-sdk-python-ags", specifier = ">=3.1.59" },
 ]
 
 [[package]]

--- a/examples/deploy-custom-image/uv.lock
+++ b/examples/deploy-custom-image/uv.lock
@@ -1,0 +1,182 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/60/e3bec1881450851b087e301bedc3daa9377a4d45f1c26aa90b0b235e38aa/charset_normalizer-3.4.6.tar.gz", hash = "sha256:1ae6b62897110aa7c79ea2f5dd38d1abca6db663687c0b1ad9aed6f6bae3d9d6", size = 143363, upload-time = "2026-03-15T18:53:25.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/28/ff6f234e628a2de61c458be2779cb182bc03f6eec12200d4a525bbfc9741/charset_normalizer-3.4.6-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:82060f995ab5003a2d6e0f4ad29065b7672b6593c8c63559beefe5b443242c3e", size = 293582, upload-time = "2026-03-15T18:50:25.454Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/b7/b1a117e5385cbdb3205f6055403c2a2a220c5ea80b8716c324eaf75c5c95/charset_normalizer-3.4.6-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60c74963d8350241a79cb8feea80e54d518f72c26db618862a8f53e5023deaf9", size = 197240, upload-time = "2026-03-15T18:50:27.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5f/2574f0f09f3c3bc1b2f992e20bce6546cb1f17e111c5be07308dc5427956/charset_normalizer-3.4.6-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6e4333fb15c83f7d1482a76d45a0818897b3d33f00efd215528ff7c51b8e35d", size = 217363, upload-time = "2026-03-15T18:50:28.601Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d1/0ae20ad77bc949ddd39b51bf383b6ca932f2916074c95cad34ae465ab71f/charset_normalizer-3.4.6-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bc72863f4d9aba2e8fd9085e63548a324ba706d2ea2c83b260da08a59b9482de", size = 212994, upload-time = "2026-03-15T18:50:30.102Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ac/3233d262a310c1b12633536a07cde5ddd16985e6e7e238e9f3f9423d8eb9/charset_normalizer-3.4.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9cc4fc6c196d6a8b76629a70ddfcd4635a6898756e2d9cac5565cf0654605d73", size = 204697, upload-time = "2026-03-15T18:50:31.654Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3c/8a18fc411f085b82303cfb7154eed5bd49c77035eb7608d049468b53f87c/charset_normalizer-3.4.6-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:0c173ce3a681f309f31b87125fecec7a5d1347261ea11ebbb856fa6006b23c8c", size = 191673, upload-time = "2026-03-15T18:50:33.433Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/a7/11cfe61d6c5c5c7438d6ba40919d0306ed83c9ab957f3d4da2277ff67836/charset_normalizer-3.4.6-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c907cdc8109f6c619e6254212e794d6548373cc40e1ec75e6e3823d9135d29cc", size = 201120, upload-time = "2026-03-15T18:50:35.105Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/10/cf491fa1abd47c02f69687046b896c950b92b6cd7337a27e6548adbec8e4/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:404a1e552cf5b675a87f0651f8b79f5f1e6fd100ee88dc612f89aa16abd4486f", size = 200911, upload-time = "2026-03-15T18:50:36.819Z" },
+    { url = "https://files.pythonhosted.org/packages/28/70/039796160b48b18ed466fde0af84c1b090c4e288fae26cd674ad04a2d703/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e3c701e954abf6fc03a49f7c579cc80c2c6cc52525340ca3186c41d3f33482ef", size = 192516, upload-time = "2026-03-15T18:50:38.228Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/34/c56f3223393d6ff3124b9e78f7de738047c2d6bc40a4f16ac0c9d7a1cb3c/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7a6967aaf043bceabab5412ed6bd6bd26603dae84d5cb75bf8d9a74a4959d398", size = 218795, upload-time = "2026-03-15T18:50:39.664Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/3b/ce2d4f86c5282191a041fdc5a4ce18f1c6bd40a5bd1f74cf8625f08d51c1/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5feb91325bbceade6afab43eb3b508c63ee53579fe896c77137ded51c6b6958e", size = 201833, upload-time = "2026-03-15T18:50:41.552Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/9b/b6a9f76b0fd7c5b5ec58b228ff7e85095370282150f0bd50b3126f5506d6/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:f820f24b09e3e779fe84c3c456cb4108a7aa639b0d1f02c28046e11bfcd088ed", size = 213920, upload-time = "2026-03-15T18:50:43.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/98/7bc23513a33d8172365ed30ee3a3b3fe1ece14a395e5fc94129541fc6003/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b35b200d6a71b9839a46b9b7fff66b6638bb52fc9658aa58796b0326595d3021", size = 206951, upload-time = "2026-03-15T18:50:44.789Z" },
+    { url = "https://files.pythonhosted.org/packages/32/73/c0b86f3d1458468e11aec870e6b3feac931facbe105a894b552b0e518e79/charset_normalizer-3.4.6-cp311-cp311-win32.whl", hash = "sha256:9ca4c0b502ab399ef89248a2c84c54954f77a070f28e546a85e91da627d1301e", size = 143703, upload-time = "2026-03-15T18:50:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/e3/76f2facfe8eddee0bbd38d2594e709033338eae44ebf1738bcefe0a06185/charset_normalizer-3.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:a9e68c9d88823b274cf1e72f28cb5dc89c990edf430b0bfd3e2fb0785bfeabf4", size = 153857, upload-time = "2026-03-15T18:50:47.563Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/dc/9abe19c9b27e6cd3636036b9d1b387b78c40dedbf0b47f9366737684b4b0/charset_normalizer-3.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:97d0235baafca5f2b09cf332cc275f021e694e8362c6bb9c96fc9a0eb74fc316", size = 142751, upload-time = "2026-03-15T18:50:49.234Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/62/c0815c992c9545347aeea7859b50dc9044d147e2e7278329c6e02ac9a616/charset_normalizer-3.4.6-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2ef7fedc7a6ecbe99969cd09632516738a97eeb8bd7258bf8a0f23114c057dab", size = 295154, upload-time = "2026-03-15T18:50:50.88Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/37/bdca6613c2e3c58c7421891d80cc3efa1d32e882f7c4a7ee6039c3fc951a/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4ea868bc28109052790eb2b52a9ab33f3aa7adc02f96673526ff47419490e21", size = 199191, upload-time = "2026-03-15T18:50:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/92/9934d1bbd69f7f398b38c5dae1cbf9cc672e7c34a4adf7b17c0a9c17d15d/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:836ab36280f21fc1a03c99cd05c6b7af70d2697e374c7af0b61ed271401a72a2", size = 218674, upload-time = "2026-03-15T18:50:54.102Z" },
+    { url = "https://files.pythonhosted.org/packages/af/90/25f6ab406659286be929fd89ab0e78e38aa183fc374e03aa3c12d730af8a/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f1ce721c8a7dfec21fcbdfe04e8f68174183cf4e8188e0645e92aa23985c57ff", size = 215259, upload-time = "2026-03-15T18:50:55.616Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ef/79a463eb0fff7f96afa04c1d4c51f8fc85426f918db467854bfb6a569ce3/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e28d62a8fc7a1fa411c43bd65e346f3bce9716dc51b897fbe930c5987b402d5", size = 207276, upload-time = "2026-03-15T18:50:57.054Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/72/d0426afec4b71dc159fa6b4e68f868cd5a3ecd918fec5813a15d292a7d10/charset_normalizer-3.4.6-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:530d548084c4a9f7a16ed4a294d459b4f229db50df689bfe92027452452943a0", size = 195161, upload-time = "2026-03-15T18:50:58.686Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/18/c82b06a68bfcb6ce55e508225d210c7e6a4ea122bfc0748892f3dc4e8e11/charset_normalizer-3.4.6-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:30f445ae60aad5e1f8bdbb3108e39f6fbc09f4ea16c815c66578878325f8f15a", size = 203452, upload-time = "2026-03-15T18:51:00.196Z" },
+    { url = "https://files.pythonhosted.org/packages/44/d6/0c25979b92f8adafdbb946160348d8d44aa60ce99afdc27df524379875cb/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ac2393c73378fea4e52aa56285a3d64be50f1a12395afef9cce47772f60334c2", size = 202272, upload-time = "2026-03-15T18:51:01.703Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3d/7fea3e8fe84136bebbac715dd1221cc25c173c57a699c030ab9b8900cbb7/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:90ca27cd8da8118b18a52d5f547859cc1f8354a00cd1e8e5120df3e30d6279e5", size = 195622, upload-time = "2026-03-15T18:51:03.526Z" },
+    { url = "https://files.pythonhosted.org/packages/57/8a/d6f7fd5cb96c58ef2f681424fbca01264461336d2a7fc875e4446b1f1346/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e5a94886bedca0f9b78fecd6afb6629142fd2605aa70a125d49f4edc6037ee6", size = 220056, upload-time = "2026-03-15T18:51:05.269Z" },
+    { url = "https://files.pythonhosted.org/packages/16/50/478cdda782c8c9c3fb5da3cc72dd7f331f031e7f1363a893cdd6ca0f8de0/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:695f5c2823691a25f17bc5d5ffe79fa90972cc34b002ac6c843bb8a1720e950d", size = 203751, upload-time = "2026-03-15T18:51:06.858Z" },
+    { url = "https://files.pythonhosted.org/packages/75/fc/cc2fcac943939c8e4d8791abfa139f685e5150cae9f94b60f12520feaa9b/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:231d4da14bcd9301310faf492051bee27df11f2bc7549bc0bb41fef11b82daa2", size = 216563, upload-time = "2026-03-15T18:51:08.564Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b7/a4add1d9a5f68f3d037261aecca83abdb0ab15960a3591d340e829b37298/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a056d1ad2633548ca18ffa2f85c202cfb48b68615129143915b8dc72a806a923", size = 209265, upload-time = "2026-03-15T18:51:10.312Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/18/c094561b5d64a24277707698e54b7f67bd17a4f857bbfbb1072bba07c8bf/charset_normalizer-3.4.6-cp312-cp312-win32.whl", hash = "sha256:c2274ca724536f173122f36c98ce188fd24ce3dad886ec2b7af859518ce008a4", size = 144229, upload-time = "2026-03-15T18:51:11.694Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/20/0567efb3a8fd481b8f34f739ebddc098ed062a59fed41a8d193a61939e8f/charset_normalizer-3.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:c8ae56368f8cc97c7e40a7ee18e1cedaf8e780cd8bc5ed5ac8b81f238614facb", size = 154277, upload-time = "2026-03-15T18:51:13.004Z" },
+    { url = "https://files.pythonhosted.org/packages/15/57/28d79b44b51933119e21f65479d0864a8d5893e494cf5daab15df0247c17/charset_normalizer-3.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:899d28f422116b08be5118ef350c292b36fc15ec2daeb9ea987c89281c7bb5c4", size = 142817, upload-time = "2026-03-15T18:51:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/1d/4fdabeef4e231153b6ed7567602f3b68265ec4e5b76d6024cf647d43d981/charset_normalizer-3.4.6-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:11afb56037cbc4b1555a34dd69151e8e069bee82e613a73bef6e714ce733585f", size = 294823, upload-time = "2026-03-15T18:51:15.755Z" },
+    { url = "https://files.pythonhosted.org/packages/47/7b/20e809b89c69d37be748d98e84dce6820bf663cf19cf6b942c951a3e8f41/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:423fb7e748a08f854a08a222b983f4df1912b1daedce51a72bd24fe8f26a1843", size = 198527, upload-time = "2026-03-15T18:51:17.177Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/4f8d27527d59c039dce6f7622593cdcd3d70a8504d87d09eb11e9fdc6062/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d73beaac5e90173ac3deb9928a74763a6d230f494e4bfb422c217a0ad8e629bf", size = 218388, upload-time = "2026-03-15T18:51:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/9b/4770ccb3e491a9bacf1c46cc8b812214fe367c86a96353ccc6daf87b01ec/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d60377dce4511655582e300dc1e5a5f24ba0cb229005a1d5c8d0cb72bb758ab8", size = 214563, upload-time = "2026-03-15T18:51:20.374Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/58/a199d245894b12db0b957d627516c78e055adc3a0d978bc7f65ddaf7c399/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:530e8cebeea0d76bdcf93357aa5e41336f48c3dc709ac52da2bb167c5b8271d9", size = 206587, upload-time = "2026-03-15T18:51:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/70/3def227f1ec56f5c69dfc8392b8bd63b11a18ca8178d9211d7cc5e5e4f27/charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:a26611d9987b230566f24a0a125f17fe0de6a6aff9f25c9f564aaa2721a5fb88", size = 194724, upload-time = "2026-03-15T18:51:23.508Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ab/9318352e220c05efd31c2779a23b50969dc94b985a2efa643ed9077bfca5/charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:34315ff4fc374b285ad7f4a0bf7dcbfe769e1b104230d40f49f700d4ab6bbd84", size = 202956, upload-time = "2026-03-15T18:51:25.239Z" },
+    { url = "https://files.pythonhosted.org/packages/75/13/f3550a3ac25b70f87ac98c40d3199a8503676c2f1620efbf8d42095cfc40/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5f8ddd609f9e1af8c7bd6e2aca279c931aefecd148a14402d4e368f3171769fd", size = 201923, upload-time = "2026-03-15T18:51:26.682Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/db/c5c643b912740b45e8eec21de1bbab8e7fc085944d37e1e709d3dcd9d72f/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:80d0a5615143c0b3225e5e3ef22c8d5d51f3f72ce0ea6fb84c943546c7b25b6c", size = 195366, upload-time = "2026-03-15T18:51:28.129Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/3b1c62744f9b2448443e0eb160d8b001c849ec3fef591e012eda6484787c/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:92734d4d8d187a354a556626c221cd1a892a4e0802ccb2af432a1d85ec012194", size = 219752, upload-time = "2026-03-15T18:51:29.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/98/32ffbaf7f0366ffb0445930b87d103f6b406bc2c271563644bde8a2b1093/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:613f19aa6e082cf96e17e3ffd89383343d0d589abda756b7764cf78361fd41dc", size = 203296, upload-time = "2026-03-15T18:51:30.921Z" },
+    { url = "https://files.pythonhosted.org/packages/41/12/5d308c1bbe60cabb0c5ef511574a647067e2a1f631bc8634fcafaccd8293/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:2b1a63e8224e401cafe7739f77efd3f9e7f5f2026bda4aead8e59afab537784f", size = 215956, upload-time = "2026-03-15T18:51:32.399Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e9/5f85f6c5e20669dbe56b165c67b0260547dea97dba7e187938833d791687/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6cceb5473417d28edd20c6c984ab6fee6c6267d38d906823ebfe20b03d607dc2", size = 208652, upload-time = "2026-03-15T18:51:34.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/11/897052ea6af56df3eef3ca94edafee410ca699ca0c7b87960ad19932c55e/charset_normalizer-3.4.6-cp313-cp313-win32.whl", hash = "sha256:d7de2637729c67d67cf87614b566626057e95c303bc0a55ffe391f5205e7003d", size = 143940, upload-time = "2026-03-15T18:51:36.15Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5c/724b6b363603e419829f561c854b87ed7c7e31231a7908708ac086cdf3e2/charset_normalizer-3.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:572d7c822caf521f0525ba1bce1a622a0b85cf47ffbdae6c9c19e3b5ac3c4389", size = 154101, upload-time = "2026-03-15T18:51:37.876Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a5/7abf15b4c0968e47020f9ca0935fb3274deb87cb288cd187cad92e8cdffd/charset_normalizer-3.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a4474d924a47185a06411e0064b803c68be044be2d60e50e8bddcc2649957c1f", size = 143109, upload-time = "2026-03-15T18:51:39.565Z" },
+    { url = "https://files.pythonhosted.org/packages/25/6f/ffe1e1259f384594063ea1869bfb6be5cdb8bc81020fc36c3636bc8302a1/charset_normalizer-3.4.6-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9cc6e6d9e571d2f863fa77700701dae73ed5f78881efc8b3f9a4398772ff53e8", size = 294458, upload-time = "2026-03-15T18:51:41.134Z" },
+    { url = "https://files.pythonhosted.org/packages/56/60/09bb6c13a8c1016c2ed5c6a6488e4ffef506461aa5161662bd7636936fb1/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5960d965e67165d75b7c7ffc60a83ec5abfc5c11b764ec13ea54fbef8b4421", size = 199277, upload-time = "2026-03-15T18:51:42.953Z" },
+    { url = "https://files.pythonhosted.org/packages/00/50/dcfbb72a5138bbefdc3332e8d81a23494bf67998b4b100703fd15fa52d81/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b3694e3f87f8ac7ce279d4355645b3c878d24d1424581b46282f24b92f5a4ae2", size = 218758, upload-time = "2026-03-15T18:51:44.339Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b3/d79a9a191bb75f5aa81f3aaaa387ef29ce7cb7a9e5074ba8ea095cc073c2/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5d11595abf8dd942a77883a39d81433739b287b6aa71620f15164f8096221b30", size = 215299, upload-time = "2026-03-15T18:51:45.871Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7e/bc8911719f7084f72fd545f647601ea3532363927f807d296a8c88a62c0d/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db", size = 206811, upload-time = "2026-03-15T18:51:47.308Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/40/c430b969d41dda0c465aa36cc7c2c068afb67177bef50905ac371b28ccc7/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:bbc8c8650c6e51041ad1be191742b8b421d05bbd3410f43fa2a00c8db87678e8", size = 193706, upload-time = "2026-03-15T18:51:48.849Z" },
+    { url = "https://files.pythonhosted.org/packages/48/15/e35e0590af254f7df984de1323640ef375df5761f615b6225ba8deb9799a/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22c6f0c2fbc31e76c3b8a86fba1a56eda6166e238c29cdd3d14befdb4a4e4815", size = 202706, upload-time = "2026-03-15T18:51:50.257Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/bd/f736f7b9cc5e93a18b794a50346bb16fbfd6b37f99e8f306f7951d27c17c/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7edbed096e4a4798710ed6bc75dcaa2a21b68b6c356553ac4823c3658d53743a", size = 202497, upload-time = "2026-03-15T18:51:52.012Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ba/2cc9e3e7dfdf7760a6ed8da7446d22536f3d0ce114ac63dee2a5a3599e62/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:7f9019c9cb613f084481bd6a100b12e1547cf2efe362d873c2e31e4035a6fa43", size = 193511, upload-time = "2026-03-15T18:51:53.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/cb/5be49b5f776e5613be07298c80e1b02a2d900f7a7de807230595c85a8b2e/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:58c948d0d086229efc484fe2f30c2d382c86720f55cd9bc33591774348ad44e0", size = 220133, upload-time = "2026-03-15T18:51:55.333Z" },
+    { url = "https://files.pythonhosted.org/packages/83/43/99f1b5dad345accb322c80c7821071554f791a95ee50c1c90041c157ae99/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:419a9d91bd238052642a51938af8ac05da5b3343becde08d5cdeab9046df9ee1", size = 203035, upload-time = "2026-03-15T18:51:56.736Z" },
+    { url = "https://files.pythonhosted.org/packages/87/9a/62c2cb6a531483b55dddff1a68b3d891a8b498f3ca555fbcf2978e804d9d/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5273b9f0b5835ff0350c0828faea623c68bfa65b792720c453e22b25cc72930f", size = 216321, upload-time = "2026-03-15T18:51:58.17Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/79/94a010ff81e3aec7c293eb82c28f930918e517bc144c9906a060844462eb/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0e901eb1049fdb80f5bd11ed5ea1e498ec423102f7a9b9e4645d5b8204ff2815", size = 208973, upload-time = "2026-03-15T18:51:59.998Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/57/4ecff6d4ec8585342f0c71bc03efaa99cb7468f7c91a57b105bcd561cea8/charset_normalizer-3.4.6-cp314-cp314-win32.whl", hash = "sha256:b4ff1d35e8c5bd078be89349b6f3a845128e685e751b6ea1169cf2160b344c4d", size = 144610, upload-time = "2026-03-15T18:52:02.213Z" },
+    { url = "https://files.pythonhosted.org/packages/80/94/8434a02d9d7f168c25767c64671fead8d599744a05d6a6c877144c754246/charset_normalizer-3.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:74119174722c4349af9708993118581686f343adc1c8c9c007d59be90d077f3f", size = 154962, upload-time = "2026-03-15T18:52:03.658Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4c/48f2cdbfd923026503dfd67ccea45c94fd8fe988d9056b468579c66ed62b/charset_normalizer-3.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:e5bcc1a1ae744e0bb59641171ae53743760130600da8db48cbb6e4918e186e4e", size = 143595, upload-time = "2026-03-15T18:52:05.123Z" },
+    { url = "https://files.pythonhosted.org/packages/31/93/8878be7569f87b14f1d52032946131bcb6ebbd8af3e20446bc04053dc3f1/charset_normalizer-3.4.6-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ad8faf8df23f0378c6d527d8b0b15ea4a2e23c89376877c598c4870d1b2c7866", size = 314828, upload-time = "2026-03-15T18:52:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b6/fae511ca98aac69ecc35cde828b0a3d146325dd03d99655ad38fc2cc3293/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f5ea69428fa1b49573eef0cc44a1d43bebd45ad0c611eb7d7eac760c7ae771bc", size = 208138, upload-time = "2026-03-15T18:52:08.239Z" },
+    { url = "https://files.pythonhosted.org/packages/54/57/64caf6e1bf07274a1e0b7c160a55ee9e8c9ec32c46846ce59b9c333f7008/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:06a7e86163334edfc5d20fe104db92fcd666e5a5df0977cb5680a506fe26cc8e", size = 224679, upload-time = "2026-03-15T18:52:10.043Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/cb/9ff5a25b9273ef160861b41f6937f86fae18b0792fe0a8e75e06acb08f1d/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e1f6e2f00a6b8edb562826e4632e26d063ac10307e80f7461f7de3ad8ef3f077", size = 223475, upload-time = "2026-03-15T18:52:11.854Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/97/440635fc093b8d7347502a377031f9605a1039c958f3cd18dcacffb37743/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95b52c68d64c1878818687a473a10547b3292e82b6f6fe483808fb1468e2f52f", size = 215230, upload-time = "2026-03-15T18:52:13.325Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/24/afff630feb571a13f07c8539fbb502d2ab494019492aaffc78ef41f1d1d0/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:7504e9b7dc05f99a9bbb4525c67a2c155073b44d720470a148b34166a69c054e", size = 199045, upload-time = "2026-03-15T18:52:14.752Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/17/d1399ecdaf7e0498c327433e7eefdd862b41236a7e484355b8e0e5ebd64b/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:172985e4ff804a7ad08eebec0a1640ece87ba5041d565fff23c8f99c1f389484", size = 211658, upload-time = "2026-03-15T18:52:16.278Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/38/16baa0affb957b3d880e5ac2144caf3f9d7de7bc4a91842e447fbb5e8b67/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4be9f4830ba8741527693848403e2c457c16e499100963ec711b1c6f2049b7c7", size = 210769, upload-time = "2026-03-15T18:52:17.782Z" },
+    { url = "https://files.pythonhosted.org/packages/05/34/c531bc6ac4c21da9ddfddb3107be2287188b3ea4b53b70fc58f2a77ac8d8/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:79090741d842f564b1b2827c0b82d846405b744d31e84f18d7a7b41c20e473ff", size = 201328, upload-time = "2026-03-15T18:52:19.553Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/73/a5a1e9ca5f234519c1953608a03fe109c306b97fdfb25f09182babad51a7/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:87725cfb1a4f1f8c2fc9890ae2f42094120f4b44db9360be5d99a4c6b0e03a9e", size = 225302, upload-time = "2026-03-15T18:52:21.043Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/f6/cd782923d112d296294dea4bcc7af5a7ae0f86ab79f8fefbda5526b6cfc0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:fcce033e4021347d80ed9c66dcf1e7b1546319834b74445f561d2e2221de5659", size = 211127, upload-time = "2026-03-15T18:52:22.491Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/c5/0b6898950627af7d6103a449b22320372c24c6feda91aa24e201a478d161/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ca0276464d148c72defa8bb4390cce01b4a0e425f3b50d1435aa6d7a18107602", size = 222840, upload-time = "2026-03-15T18:52:24.113Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/25/c4bba773bef442cbdc06111d40daa3de5050a676fa26e85090fc54dd12f0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:197c1a244a274bb016dd8b79204850144ef77fe81c5b797dc389327adb552407", size = 216890, upload-time = "2026-03-15T18:52:25.541Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1a/05dacadb0978da72ee287b0143097db12f2e7e8d3ffc4647da07a383b0b7/charset_normalizer-3.4.6-cp314-cp314t-win32.whl", hash = "sha256:2a24157fa36980478dd1770b585c0f30d19e18f4fb0c47c13aa568f871718579", size = 155379, upload-time = "2026-03-15T18:52:27.05Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7a/d269d834cb3a76291651256f3b9a5945e81d0a49ab9f4a498964e83c0416/charset_normalizer-3.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:cd5e2801c89992ed8c0a3f0293ae83c159a60d9a5d685005383ef4caca77f2c4", size = 169043, upload-time = "2026-03-15T18:52:28.502Z" },
+    { url = "https://files.pythonhosted.org/packages/23/06/28b29fba521a37a8932c6a84192175c34d49f84a6d4773fa63d05f9aff22/charset_normalizer-3.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:47955475ac79cc504ef2704b192364e51d0d473ad452caedd0002605f780101c", size = 148523, upload-time = "2026-03-15T18:52:29.956Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/68/687187c7e26cb24ccbd88e5069f5ef00eba804d36dde11d99aad0838ab45/charset_normalizer-3.4.6-py3-none-any.whl", hash = "sha256:947cf925bc916d90adba35a64c82aace04fa39b46b52d4630ece166655905a69", size = 61455, upload-time = "2026-03-15T18:53:23.833Z" },
+]
+
+[[package]]
+name = "deploy-custom-image"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "python-dotenv" },
+    { name = "tencentcloud-sdk-python-ags" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "python-dotenv" },
+    { name = "tencentcloud-sdk-python-ags" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "tencentcloud-sdk-python-ags"
+version = "3.1.59"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tencentcloud-sdk-python-common" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/69/aa5b3bbb028528043235b6a1be69263860ae84bea9ad7f5645fe97bd4308/tencentcloud_sdk_python_ags-3.1.59.tar.gz", hash = "sha256:8f404ddf880a6d11ee1bb2baeb5a9c4aa7dcba91fc35e6bff3656748bd0823a3", size = 18095, upload-time = "2026-03-18T20:07:36.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/03/f590284ed5b072b22f156700ccc98de764bfb356eb686179efca82c35002/tencentcloud_sdk_python_ags-3.1.59-py2.py3-none-any.whl", hash = "sha256:557da9cb57203db511cda645c703ecb32362a4e7cd1d9f7823337f41c9ee1904", size = 20964, upload-time = "2026-03-18T20:07:35.557Z" },
+]
+
+[[package]]
+name = "tencentcloud-sdk-python-common"
+version = "3.1.62"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/a3/839031782ca1857d8c43dbe7dfc105f7689ee320c8abd3f678807734aa72/tencentcloud_sdk_python_common-3.1.62.tar.gz", hash = "sha256:9709db22c18a321607e4ba1b280ef8a262e6761ffd4991565af7df6b95552cca", size = 22652, upload-time = "2026-03-23T21:41:40.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7a/434cabc80780ac0e2b58e98a250686bfdf5e00dd4f50604ac8c2d0087a6a/tencentcloud_sdk_python_common-3.1.62-py2.py3-none-any.whl", hash = "sha256:dd249960f2504e7c014a312e8ca8996e47476d8db90a58610d154862159e4db9", size = 34264, upload-time = "2026-03-23T21:41:37.845Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]


### PR DESCRIPTION
## Summary

- Add `deploy-custom-image` example: a one-click workflow to deploy any existing Docker image as a custom AGS sandbox tool
- The script automatically inspects the source image (ENTRYPOINT, CMD, EXPOSE, HEALTHCHECK) and configures the sandbox tool accordingly
- Builds a thin wrapper image (injecting envd via multi-stage `COPY --from`), pushes to Tencent Cloud CCR, and creates/updates the AGS tool via control-plane API

## New files

| File | Description |
|------|-------------|
| `examples/deploy-custom-image/main.py` | One-click deployment script |
| `examples/deploy-custom-image/Dockerfile` | Thin wrapper (injects envd from `ccr.ccs.tencentyun.com/ags-image/envd:latest`) |
| `examples/deploy-custom-image/.env.example` | Configuration template |
| `examples/deploy-custom-image/Makefile` | `make setup` / `make run` |
| `examples/deploy-custom-image/pyproject.toml` | Python dependencies |
| `examples/deploy-custom-image/README.md` | English documentation |
| `examples/deploy-custom-image/README_zh.md` | Chinese documentation |

## Modified files

- `examples/README.md` — add `deploy-custom-image` to example list
- `examples/README_zh.md` — same

## Test plan

- [x] Tested with `nginx:latest` — auto-detected ENTRYPOINT + CMD + port 80, tool created successfully
- [x] Tested with `grafana/grafana:latest` — auto-detected ENTRYPOINT + port 3000, tool created successfully
- [x] Tested with `ccr.ccs.tencentyun.com/ags-image/sandbox-browser:latest` — auto-detected ENTRYPOINT + 4 ports, tool created successfully
- [x] Verified `make setup && make run` flow end-to-end
- [x] Verified `.gitignore` excludes `.env`, `.venv/`, `__pycache__/`

Made with [Cursor](https://cursor.com)