### PR TITLE
feat(examples): add mini-swe-agent cookbook which use swe-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ You can also enter an example directory directly and run its local `make setup` 
 | `html-processing` | Python + browser/code sandboxes | Dual-sandbox HTML pipeline |
 | `hybrid-cookbook` | Go | Minimal control-plane + data-plane flow |
 | `mini-rl` | Python + code sandbox | Minimal RL tool-calling example |
+| `mini-swe-agent` | Python + SWE sandbox + LLM | SWE-bench evaluation with AGS SWE sandbox |
 | `mobile-use` | Python + mobile sandbox + Appium | Android automation |
 | `openclaw-cookbook` | Node.js + custom image + COS | Run OpenClaw in AGS with official image |
 | `osworld-ags` | Python 3.10 + OSWorld overlay | Heavy setup; requires an OSWorld-capable tool |

--- a/README_zh.md
+++ b/README_zh.md
@@ -72,6 +72,7 @@ make example-run EXAMPLE=mini-rl
 | `html-processing` | Python + Browser/Code 双沙箱 | HTML 协作处理 |
 | `hybrid-cookbook` | Go | 最小控制面 + 数据面流程 |
 | `mini-rl` | Python + 代码沙箱 | 最小 RL Tool Calling 示例 |
+| `mini-swe-agent` | Python + SWE 沙箱 + LLM | 使用 AGS SWE 沙箱运行 SWE-bench 评测 |
 | `mobile-use` | Python + 移动端沙箱 + Appium | Android 自动化 |
 | `openclaw-cookbook` | Node.js + 自定义镜像 + COS | 基于官方镜像在 AGS 中运行 OpenClaw |
 | `osworld-ags` | Python 3.10 + OSWorld overlay | 依赖重，且需要可用的 OSWorld 工具 |

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ This directory contains runnable AGS examples. Each example keeps its own README
 
 - `browser-agent` — browser automation agent with an OpenAI-compatible LLM backend
 - `data-analysis` — multi-context data workflow with multiple generated artifacts
+- `mini-swe-agent` — SWE-bench evaluation with AGS SWE sandbox and SWE-ReX runtime
 - `mobile-use` — Android / Appium automation in AGS
 - `openclaw-cookbook` — run OpenClaw in AGS with official image, local management UI and COS persistence
 - `shop-assistant` — browser shopping-flow automation with optional cookies
@@ -43,6 +44,7 @@ Some heavier or externally overlaid examples are exceptions, but they should sti
 | `html-processing` | starter | Python + browser/code sandboxes | `make run` | Good visual intro to dual-sandbox flow |
 | `hybrid-cookbook` | starter | Go | `make run` | Minimal Go integration path |
 | `mini-rl` | starter | Python + code sandbox | `make run` | Smallest Python example |
+| `mini-swe-agent` | advanced | Python + SWE sandbox + LLM | `make run` | SWE-bench evaluation; requires mini-swe-agent and SWE-ReX repos |
 | `mobile-use` | advanced | Python + mobile sandbox + Appium | `make run` | Heavy runtime dependencies and long-running device flow |
 | `openclaw-cookbook` | advanced | Node.js + custom image + COS | `make run` | Run OpenClaw in AGS with official image; includes local management UI |
 | `osworld-ags` | heavy | Python 3.10 + OSWorld overlay | `make setup` then `make run` | External checkout and template/tool requirements |

--- a/examples/README_zh.md
+++ b/examples/README_zh.md
@@ -14,6 +14,7 @@
 
 - `browser-agent` —— 基于 OpenAI-compatible LLM 的浏览器自动化 Agent
 - `data-analysis` —— 多 Context 数据工作流，生成多个产物
+- `mini-swe-agent` —— 基于 AGS SWE Sandbox 和 SWE-ReX runtime 运行 SWE-bench 评测
 - `mobile-use` —— 在 AGS 中运行 Android / Appium 自动化
 - `openclaw-cookbook` —— 基于官方镜像在 AGS 中运行 OpenClaw，含本地管理界面与 COS 持久化
 - `shop-assistant` —— 浏览器购物流程自动化，支持无 Cookie 的 guest 模式
@@ -43,6 +44,7 @@
 | `html-processing` | 入门 | Python + 浏览器/代码双沙箱 | `make run` | 适合作为双沙箱协作的直观起点 |
 | `hybrid-cookbook` | 入门 | Go | `make run` | 最小 Go 集成路径 |
 | `mini-rl` | 入门 | Python + 代码沙箱 | `make run` | 最小 Python 示例 |
+| `mini-swe-agent` | 进阶 | Python + SWE 沙箱 + LLM | `make run` | 使用 AGS SWE Sandbox 运行 SWE-bench Verified 评测 |
 | `mobile-use` | 进阶 | Python + 移动端沙箱 + Appium | `make run` | 运行时依赖较重，且流程较长 |
 | `openclaw-cookbook` | 进阶 | Node.js + 自定义镜像 + COS | `make run` | 基于官方镜像在 AGS 中运行 OpenClaw；含本地管理界面 |
 | `osworld-ags` | 重型 | Python 3.10 + OSWorld overlay | `make setup` 后 `make run` | 需要外部 checkout 与模板 / 工具准备 |

--- a/examples/mini-swe-agent/.env.example
+++ b/examples/mini-swe-agent/.env.example
@@ -1,0 +1,10 @@
+# Copy this file to .env and fill in real values
+
+# Tencent Cloud credentials for AGS
+TENCENTCLOUD_SECRET_ID="your-secret-id"
+TENCENTCLOUD_SECRET_KEY="your-secret-key"
+
+# Optional: use local HuggingFace dataset cache to skip update checks.
+# Set to 1 only if you have already downloaded the dataset.
+# If unset, the dataset will be downloaded on first run.
+# HF_DATASETS_OFFLINE=1

--- a/examples/mini-swe-agent/.gitignore
+++ b/examples/mini-swe-agent/.gitignore
@@ -1,0 +1,16 @@
+# Cloned upstream repos (created by `make setup`)
+/mini-swe-agent/
+
+# Runtime outputs
+results/
+
+# Local config (contains credentials)
+my_config.yaml
+.env
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+.venv/

--- a/examples/mini-swe-agent/Makefile
+++ b/examples/mini-swe-agent/Makefile
@@ -1,0 +1,77 @@
+REPO_DIR := mini-swe-agent
+SWEREX_DIR := $(REPO_DIR)/SWE-ReX
+RESULTS_DIR := $(CURDIR)/results
+WORKERS ?= 4
+PYTHON_VERSION ?= 3.12
+
+MINI_SWE_AGENT_REPO := https://github.com/SWE-agent/mini-SWE-agent.git
+SWEREX_REPO := https://github.com/SWE-agent/SWE-ReX.git
+
+.PHONY: setup run run-full logs tail clean
+
+setup:
+	@echo "Setting up mini-swe-agent with AGS support (overlay mode)..."
+	@command -v uv >/dev/null 2>&1 || { echo "Error: uv is required. Install from https://github.com/astral-sh/uv"; exit 1; }
+	@test -d $(REPO_DIR) || git clone --depth 1 $(MINI_SWE_AGENT_REPO) $(REPO_DIR)
+	@test -d $(SWEREX_DIR) || git clone --depth 1 $(SWEREX_REPO) $(SWEREX_DIR)
+	@echo "Applying AGS overlay to mini-swe-agent..."
+	cp -R overlay/mini-swe-agent/. $(REPO_DIR)/
+	@echo "Applying AGS overlay to SWE-ReX..."
+	cp -R overlay/SWE-ReX/. $(SWEREX_DIR)/
+	@test -d $(REPO_DIR)/.venv || (cd $(REPO_DIR) && uv venv --python $(PYTHON_VERSION))
+	cd $(REPO_DIR) && \
+		uv pip install -e "./SWE-ReX[ags]" && \
+		uv pip install -e ".[full,ags]"
+	@echo ""
+	@echo "Setup complete."
+	@echo "  1. Copy .env.example to .env and fill in your Tencent Cloud credentials."
+	@echo "  2. Create my_config.yaml with your tool_id and LLM settings (see README)."
+
+run:
+	@test -d $(REPO_DIR)/.venv || { echo "Error: run 'make setup' first."; exit 1; }
+	@test -f my_config.yaml || { echo "Error: my_config.yaml not found. See README.md for setup instructions."; exit 1; }
+	@mkdir -p $(RESULTS_DIR)
+	@if [ -f .env ]; then set -a; . ./.env; set +a; fi; \
+	cd $(REPO_DIR) && \
+		uv run mini-extra swebench-single \
+		-c swebench_ags \
+		-c $(CURDIR)/my_config.yaml \
+		-o $(RESULTS_DIR)/interactive.traj.json \
+		--subset verified \
+		--split test \
+		-i 0 -y
+	@echo "Run complete. Trajectory saved to $(RESULTS_DIR)/interactive.traj.json"
+
+run-full:
+	@test -d $(REPO_DIR)/.venv || { echo "Error: run 'make setup' first."; exit 1; }
+	@test -f my_config.yaml || { echo "Error: my_config.yaml not found. See README.md for setup instructions."; exit 1; }
+	@mkdir -p $(RESULTS_DIR)
+	@if [ -f .env ]; then set -a; . ./.env; set +a; fi; \
+	cd $(REPO_DIR) && \
+		uv run mini-extra swebench \
+		-c swebench_ags \
+		-c $(CURDIR)/my_config.yaml \
+		-o $(RESULTS_DIR) \
+		--subset verified \
+		--split test \
+		-w $(WORKERS)
+
+logs:
+	@test -f $(RESULTS_DIR)/minisweagent.log || { echo "No log file found. Run 'make run-full' first."; exit 1; }
+	@tail -f $(RESULTS_DIR)/minisweagent.log
+
+tail:
+	@if stat --version >/dev/null 2>&1; then \
+		file="$$(find $(RESULTS_DIR) -name "*.traj.json" -exec stat -c '%Y %n' {} \; 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)"; \
+		else \
+		file="$$(find $(RESULTS_DIR) -name "*.traj.json" -exec stat -f '%m %N' {} \; 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)"; \
+	fi; \
+	if [ -n "$$file" ]; then \
+		echo "Latest trajectory: $$file"; \
+		jq . "$$file"; \
+	else \
+		echo "No trajectory files found"; \
+	fi
+
+clean:
+	rm -rf $(REPO_DIR) $(RESULTS_DIR)

--- a/examples/mini-swe-agent/README.md
+++ b/examples/mini-swe-agent/README.md
@@ -1,0 +1,250 @@
+# Mini-SWE-Agent: SWE-bench Evaluation with AGS SWE Sandbox
+
+This example demonstrates how to run [SWE-bench Verified](https://huggingface.co/datasets/princeton-nlp/SWE-Bench_Verified) evaluations using [mini-swe-agent](https://github.com/SWE-agent/mini-SWE-agent) with Tencent Cloud AGS SWE Sandbox.
+
+It works by applying a small overlay onto official upstream repositories. The overlay adds AGS sandbox support without requiring any private forks.
+
+## How It Works
+
+```
+Official upstream repos          AGS overlay (this cookbook)
+┌────────────────────┐          ┌────────────────────┐
+│ SWE-agent/         │          │ overlay/            │
+│   mini-SWE-agent   │  ← cp ──│   mini-swe-agent/   │  (AGS environment, logging fixes)
+│ SWE-agent/         │          │   SWE-ReX/          │  (AGS deployment + runtime)
+│   SWE-ReX          │  ← cp ──│                     │
+└────────────────────┘          └────────────────────┘
+```
+
+The overlay adds:
+- AGS SWE sandbox environment wrapper for mini-swe-agent
+- AGS deployment provider and runtime for SWE-ReX
+- Thread-safe logging to avoid deadlocks with Rich Live progress display
+- SWE-bench AGS benchmark configuration
+
+See [overlay/OVERLAY.md](overlay/OVERLAY.md) for a detailed list of every overlaid file.
+
+## Prerequisites
+
+- Python >= 3.10 (3.12 recommended; used by default in `make setup`. Override with `make setup PYTHON_VERSION=3.10`)
+- [uv](https://github.com/astral-sh/uv) — Python package manager
+- Tencent Cloud account with AGS access (`SecretId` and `SecretKey`)
+- An AGS SWE sandbox tool (see Step 1 below)
+- An LLM API key (OpenAI, Anthropic, or any OpenAI-compatible endpoint)
+
+## Quick Start
+
+### 1. Create SWE Sandbox Tool (one-time)
+
+1. Log in to the [Tencent Cloud AGS Console](https://console.cloud.tencent.com/ags).
+2. Go to **Environment Tools** > **SWE Sandbox**.
+3. Click **Create Sandbox Tool**, leave tool configuration empty, choose public network, and submit.
+4. Record the **Tool ID** (e.g., `sdt-xxxxxxxx`).
+
+This only needs to be done once — all sandbox instances reuse the same tool ID.
+
+### 2. Configure Environment Variables
+
+```bash
+cp .env.example .env
+# Edit .env with your Tencent Cloud credentials
+```
+
+### 3. Install (clone + overlay + install)
+
+```bash
+make setup
+```
+
+This will:
+- Check that `uv` is installed
+- Clone (if needed) and install [SWE-ReX](https://github.com/SWE-agent/SWE-ReX) in editable mode with AGS SDK dependencies (`tencentcloud-sdk-python-common`, `tencentcloud-sdk-python-ags`)
+- Clone (if needed) and install [mini-swe-agent](https://github.com/SWE-agent/mini-SWE-agent) in editable mode with full dependencies
+- Apply the AGS overlay from `overlay/`
+
+### 4. Create Local Config
+
+Create `my_config.yaml` with your credentials and LLM settings:
+
+```yaml
+environment:
+  tool_id: "sdt-xxxxxxxx"                    # Tool ID from Step 1
+  region: "ap-chongqing"                     # AGS region (default: ap-chongqing)
+
+model:
+  model_name: "anthropic/claude-sonnet-4-5"
+  model_kwargs:
+    api_key: "sk-ant-xxxxx"
+```
+
+Security note: `my_config.yaml` is intended to stay local. Prefer environment variables for API keys when possible.
+
+**Region Configuration**: The default region is `ap-chongqing`. If your AGS tool was created in a different region, update the `region` field. Check your [AGS Console](https://console.cloud.tencent.com/ags/sandbox/tool) to find the correct region.
+
+For custom API endpoints (e.g., self-hosted or proxy models), the `model_name` must follow [litellm's provider/model format](https://docs.litellm.ai/docs/providers). Since custom models are not in litellm's cost registry, set `cost_tracking: "ignore_errors"`:
+
+```yaml
+model:
+  model_name: "openai/your-model-name"
+  cost_tracking: "ignore_errors"
+  model_kwargs:
+    api_base: "https://your-api-endpoint.com/v1"
+    api_key: "your-key"
+```
+
+### 5. Run
+
+**Run a single instance (interactive mode):**
+
+```bash
+make run
+```
+
+This runs one SWE-bench Verified instance in interactive mode, showing each agent step in real-time. Trajectory is saved to `results/interactive.traj.json`.
+
+**Run full benchmark with concurrency:**
+
+```bash
+make run-full
+```
+
+This runs all 500 SWE-bench Verified instances with 4 concurrent workers. Override with `make run-full WORKERS=8`.
+
+## Run Commands
+
+| Command | Description |
+|---------|-------------|
+| `make setup` | Clone official repos, apply overlay, install dependencies |
+| `make run` | Run a single instance in interactive mode (default `-i 0 -y`) |
+| `make run-full` | Run all 500 SWE-bench Verified instances (default: `WORKERS=4`) |
+| `make logs` | Tail the debug log file (run after `make run-full`) |
+| `make tail` | Pretty-print the most recently updated trajectory JSON |
+| `make clean` | Remove cloned repos and results |
+
+## Results
+
+Results are saved to the `results/` directory:
+
+```
+results/
+├── interactive.traj.json                          # Trajectory from `make run`
+├── minisweagent.log                              # Run log from `make run-full`
+├── preds.json                                    # Predictions from `make run-full`
+├── exit_statuses_*.yaml                          # Exit status summary
+└── <instance_id>/
+    └── <instance_id>.traj.json                   # Per-instance trajectory
+```
+
+## Configuration
+
+The evaluation uses a layered config system. Multiple `-c` configs are merged in order:
+
+| Config | Purpose |
+|--------|---------|
+| `swebench_ags` | Built-in base config: prompt templates, timeouts, AGS endpoint defaults |
+| `my_config.yaml` | Your credentials, tool ID, and LLM settings |
+
+Key parameters in the base config (`swebench_ags`):
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `environment.tool_id` | (required) | AGS SWE sandbox tool ID from console |
+| `environment.region` | `"ap-chongqing"` | AGS region where your tool is deployed |
+| `environment.timeout` | `60` | Per-command execution timeout in seconds |
+| `environment.startup_timeout` | `120` | Sandbox instance startup timeout in seconds |
+| `environment.runtime_timeout` | `60` | SWE-ReX HTTP request timeout in seconds |
+| `environment.timeout_duration` | `"1h"` | Sandbox instance total lifetime |
+| `agent.step_limit` | `250` | Max agent steps per instance |
+| `agent.cost_limit` | `3.0` | Max LLM cost per instance (USD) |
+
+**Timeout details:**
+
+- **`timeout`** (60s = 1 min): The maximum time a single bash command can run inside the sandbox. If the agent issues a command (e.g., running tests) that exceeds this limit, it is killed and a `CommandTimeoutError` is raised.
+- **`startup_timeout`** (120s = 2 min): How long to wait for a new AGS sandbox instance to be created and become ready. This includes image pull and container initialization on the AGS side.
+- **`runtime_timeout`** (60s = 1 min): The HTTP request timeout for each SWE-ReX API call (e.g., `is_alive`, `execute`). This does **not** limit command execution time — it only limits the network round-trip. If the AGS gateway is slow to respond, increase this value.
+- **`timeout_duration`** ("1h"): The total lifetime of the sandbox instance on the AGS side. After this period, AGS automatically reclaims the instance. Any subsequent API calls will receive a 404 and raise `EnvironmentExpiredError`. For long-running instances with many agent steps, increase to `"2h"` or more.
+
+All timeout values can be overridden in `my_config.yaml`:
+
+```yaml
+environment:
+  timeout: 120           # 2 min per command
+  startup_timeout: 300   # 5 min for instance creation
+  runtime_timeout: 120   # 2 min HTTP timeout
+  timeout_duration: "2h" # 2 hour instance lifetime
+```
+
+## AGS System Images
+
+AGS provides **system images** — pre-built and pre-warmed container images hosted within the AGS platform. These images are ready to use out of the box, with no need to pull or build them yourself.
+
+When you create a sandbox instance with a system image, it starts significantly faster because the image layers are already cached locally.
+
+In this example, mini-swe-agent automatically derives the image name from each SWE-bench instance and passes it to AGS as a system image:
+
+```json
+{
+    "ToolId": "sdt-xxxxxxxx",
+    "ClientToken": "unique-request-id",
+    "Timeout": "1h",
+    "CustomConfiguration": {
+        "Image": "swebench/sweb.eval.x86_64.django__django-16379:latest",
+        "ImageRegistryType": "system"
+    }
+}
+```
+
+You can browse available system images on the [AGS System Image Management page](https://console.cloud.tencent.com/ags/sandbox/template).
+
+> **Note**: Not all 500 SWE-bench Verified images are available as system images. Check the dashboard and use `--filter` to run only supported instances.
+
+## Common Failure Modes
+
+### `Failed to check image availability`
+
+The SWE-bench image for this instance is not available as a system image in AGS. Check the [AGS System Image Management page](https://console.cloud.tencent.com/ags/sandbox/template) and use `--filter` to run only supported instances.
+
+### `CommandTimeoutError: Timeout (60s) exceeded`
+
+A single command took longer than `environment.timeout`. Increase it in your config:
+
+```yaml
+environment:
+  timeout: 120  # 2 minutes
+```
+
+### `404 Not Found` / `EnvironmentExpiredError`
+
+The AGS sandbox instance has expired or was stopped. SWE-ReX raises an `EnvironmentExpiredError` immediately. The instance is marked as a failed environment task.
+
+If this happens frequently, increase the sandbox lifetime:
+
+```yaml
+environment:
+  timeout_duration: "2h"
+```
+
+### `Error calculating cost for model`
+
+Add `cost_tracking: "ignore_errors"` to your model config.
+
+### `RuntimeError: SandboxTool sdt-xxx not found`
+
+Verify the tool ID, region, and tool status on the [AGS Console](https://console.cloud.tencent.com/ags).
+
+## Updating When Upstream Changes
+
+Since the overlay is applied on top of official upstream repos, you can update by:
+
+```bash
+make clean
+make setup
+```
+
+If the upstream has changed files that the overlay also modifies, you may need to update the overlay files. See [overlay/OVERLAY.md](overlay/OVERLAY.md) for details on each overlaid file.
+
+## Notes
+
+- This is not an official upstream mini-swe-agent or SWE-ReX release.
+- The AGS integration is distributed as a cookbook overlay.
+- Upstream projects: [SWE-agent/mini-SWE-agent](https://github.com/SWE-agent/mini-SWE-agent), [SWE-agent/SWE-ReX](https://github.com/SWE-agent/SWE-ReX)

--- a/examples/mini-swe-agent/README_zh.md
+++ b/examples/mini-swe-agent/README_zh.md
@@ -1,0 +1,236 @@
+# Mini-SWE-Agent：使用 AGS SWE 沙箱运行 SWE-bench 评测
+
+本示例演示如何使用 [mini-swe-agent](https://github.com/SWE-agent/mini-SWE-agent) 配合腾讯云 AGS SWE 沙箱运行 [SWE-bench Verified](https://huggingface.co/datasets/princeton-nlp/SWE-Bench_Verified) 评测。
+
+本示例采用 overlay 模式：在官方上游仓库基础上叠加 AGS 适配层，无需依赖任何私有 fork。
+
+## 工作原理
+
+```
+官方上游仓库                        AGS overlay（本 Cookbook）
+┌────────────────────┐          ┌────────────────────┐
+│ SWE-agent/         │          │ overlay/            │
+│   mini-SWE-agent   │  ← cp ──│   mini-swe-agent/   │  (AGS 环境封装、日志修复)
+│ SWE-agent/         │          │   SWE-ReX/          │  (AGS 部署 + 运行时)
+│   SWE-ReX          │  ← cp ──│                     │
+└────────────────────┘          └────────────────────┘
+```
+
+overlay 添加了：
+- mini-swe-agent 的 AGS SWE 沙箱环境封装
+- SWE-ReX 的 AGS 部署 Provider 和 Runtime
+- 线程安全的日志架构，避免与 Rich Live 进度条死锁
+- SWE-bench AGS 评测配置
+
+详见 [overlay/OVERLAY.md](overlay/OVERLAY.md) 了解每个 overlay 文件的详细说明。
+
+## 前置条件
+
+- Python >= 3.10（推荐 3.12，`make setup` 默认使用 3.12。可通过 `make setup PYTHON_VERSION=3.10` 覆盖）
+- [uv](https://github.com/astral-sh/uv) — Python 包管理工具
+- 腾讯云账号，已开通 AGS 服务（获取 `SecretId` 和 `SecretKey`）
+- 一个 AGS SWE 沙箱工具（参见下方第 1 步）
+- LLM API Key（OpenAI、Anthropic 或任意 OpenAI 兼容端点）
+
+## 快速开始
+
+### 1. 创建 SWE 沙箱工具（一次性操作）
+
+1. 登录 [腾讯云 AGS 控制台](https://console.cloud.tencent.com/ags)。
+2. 进入「环境工具」>「SWE 沙箱」。
+3. 点击「新建沙箱工具」，工具配置留空，网络配置选择公网，直接提交创建。
+4. 记录 **工具 ID**（格式如 `sdt-xxxxxxxx`）。
+
+工具只需创建一次，后续所有沙箱实例复用同一个工具 ID。
+
+### 2. 配置环境变量
+
+```bash
+cp .env.example .env
+# 编辑 .env 填入腾讯云凭据
+```
+
+### 3. 安装（克隆 + overlay + 安装）
+
+```bash
+make setup
+```
+
+该命令会：
+- 检查 `uv` 是否已安装
+- 如果需要则克隆并安装 [SWE-ReX](https://github.com/SWE-agent/SWE-ReX)，包含 AGS SDK 依赖（`tencentcloud-sdk-python-common`、`tencentcloud-sdk-python-ags`）
+- 如果需要则克隆并安装 [mini-swe-agent](https://github.com/SWE-agent/mini-SWE-agent)，包含完整依赖
+- 将 `overlay/` 目录下的 AGS 适配代码覆盖到对应仓库中
+
+### 4. 创建本地配置
+
+创建 `my_config.yaml`，填入凭据和 LLM 配置：
+
+```yaml
+environment:
+  tool_id: "sdt-xxxxxxxx"                    # 第 1 步获取的工具 ID
+  region: "ap-chongqing"                     # AGS 地域（默认：ap-chongqing）
+
+model:
+  model_name: "anthropic/claude-sonnet-4-5"
+  model_kwargs:
+    api_key: "sk-ant-xxxxx"
+```
+
+安全提示：`my_config.yaml` 只应保留在本地，能用环境变量时更建议走环境变量。
+
+**地域配置说明**：默认地域为 `ap-chongqing`（重庆）。如果你的 AGS 工具创建在其他地域，修改 `region` 即可。请在 [AGS 控制台](https://console.cloud.tencent.com/ags/sandbox/tool) 查看你的工具所在地域。
+
+如果使用自定义 API 端点（如自建模型或代理），`model_name` 需要符合 [litellm 的 provider/model 格式](https://docs.litellm.ai/docs/providers)。自定义模型还需要设置 `cost_tracking: "ignore_errors"`：
+
+```yaml
+model:
+  model_name: "openai/your-model-name"
+  cost_tracking: "ignore_errors"
+  model_kwargs:
+    api_base: "https://your-api-endpoint.com/v1"
+    api_key: "your-key"
+```
+
+### 5. 运行
+
+**运行单个 instance（交互模式）：**
+
+```bash
+make run
+```
+
+以交互模式运行一个 SWE-bench Verified instance，实时显示每一步的思考、动作和输出。轨迹保存在 `results/interactive.traj.json`。
+
+**完整评测（4 并发）：**
+
+```bash
+make run-full
+```
+
+运行全部 500 个 SWE-bench Verified instance，4 个并发 worker。可用 `make run-full WORKERS=8` 覆盖。
+
+## 运行命令
+
+| 命令 | 说明 |
+|------|------|
+| `make setup` | 克隆官方仓库、应用 overlay、安装所有依赖 |
+| `make run` | 以交互模式运行单个 instance（默认 `-i 0 -y`） |
+| `make run-full` | 运行全部 500 个 instance（默认 `WORKERS=4`） |
+| `make logs` | 跟踪调试日志（在 `make run-full` 之后运行） |
+| `make tail` | 美化输出最近更新的 trajectory JSON |
+| `make clean` | 删除克隆的仓库和结果目录 |
+
+## 结果
+
+结果保存在 `results/` 目录下：
+
+```
+results/
+├── interactive.traj.json                          # `make run` 的轨迹文件
+├── minisweagent.log                              # `make run-full` 的运行日志
+├── preds.json                                    # 所有 instance 的预测结果
+├── exit_statuses_*.yaml                          # 退出状态汇总
+└── <instance_id>/
+    └── <instance_id>.traj.json                   # 每个 instance 的完整轨迹
+```
+
+## 配置说明
+
+评测使用分层配置系统，多个 `-c` 配置按顺序合并：
+
+| 配置 | 用途 |
+|------|------|
+| `swebench_ags` | 内置基础配置：prompt 模板、超时参数、AGS 端点默认值 |
+| `my_config.yaml` | 你的凭据、工具 ID、LLM 设置 |
+
+基础配置中的关键参数：
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `environment.tool_id` | （必填） | AGS SWE 沙箱工具 ID |
+| `environment.region` | `"ap-chongqing"` | AGS 地域 |
+| `environment.timeout` | `60` | 单条命令执行超时（秒） |
+| `environment.startup_timeout` | `120` | 沙箱实例启动超时（秒） |
+| `environment.runtime_timeout` | `60` | SWE-ReX HTTP 请求超时（秒） |
+| `environment.timeout_duration` | `"1h"` | 沙箱实例总存活时间 |
+| `agent.step_limit` | `250` | 每个 instance 的最大 Agent 步数 |
+| `agent.cost_limit` | `3.0` | 每个 instance 的最大 LLM 费用（USD） |
+
+**超时参数详解：**
+
+- **`timeout`**（60s = 1 分钟）：沙箱内单条 bash 命令的最大执行时间。Agent 每一步执行的命令（如跑测试）如果超过该时限，会被终止并抛出 `CommandTimeoutError`。
+- **`startup_timeout`**（120s = 2 分钟）：等待 AGS 创建沙箱实例并就绪的最大时间，包括镜像拉取和容器初始化。
+- **`runtime_timeout`**（60s = 1 分钟）：SWE-ReX 每次 API 调用（如 `is_alive`、`execute`）的 HTTP 请求超时。注意这**不限制**命令执行时间，只限制网络往返。如果 AGS 网关响应较慢，可以调大此值。
+- **`timeout_duration`**（"1h"）：沙箱实例在 AGS 侧的总存活时间。超过该时限后 AGS 会自动回收实例，后续 API 调用会收到 404 并抛出 `EnvironmentExpiredError`。对于步数较多的长时间任务，建议调大到 `"2h"` 或更长。
+
+所有超时参数均可在 `my_config.yaml` 中覆盖：
+
+```yaml
+environment:
+  timeout: 120           # 单条命令 2 分钟
+  startup_timeout: 300   # 实例创建 5 分钟
+  runtime_timeout: 120   # HTTP 超时 2 分钟
+  timeout_duration: "2h" # 实例存活 2 小时
+```
+
+## AGS 系统镜像
+
+AGS 提供了**系统镜像** —— 内置在 AGS 平台中、经过镜像预热的容器镜像。使用系统镜像创建沙箱实例时，启动速度显著更快。
+
+在本示例中，mini-swe-agent 会自动根据每个 SWE-bench instance 推导出镜像名称，并以系统镜像方式传给 AGS：
+
+```json
+{
+    "ToolId": "sdt-xxxxxxxx",
+    "ClientToken": "unique-request-id",
+    "Timeout": "1h",
+    "CustomConfiguration": {
+        "Image": "swebench/sweb.eval.x86_64.django__django-16379:latest",
+        "ImageRegistryType": "system"
+    }
+}
+```
+
+可以在 [AGS 系统镜像管理页面](https://console.cloud.tencent.com/ags/sandbox/template) 查看所有可用的系统镜像。
+
+> **注意**：并非全部 500 个 SWE-bench Verified 镜像都已作为系统镜像提供。请在看板中确认支持的镜像列表，并使用 `--filter` 只运行已支持的 instance。
+
+## 常见失败原因
+
+### `Failed to check image availability`
+
+该 instance 对应的镜像未在 AGS 中作为系统镜像提供。在 [AGS 系统镜像管理页面](https://console.cloud.tencent.com/ags/sandbox/template) 查看可用镜像列表，并使用 `--filter` 只运行支持的 instance。
+
+### `CommandTimeoutError: Timeout (60s) exceeded`
+
+某一条命令执行超时。在配置中增大 `environment.timeout`。
+
+### `404 Not Found` / `EnvironmentExpiredError`
+
+AGS 沙箱实例已过期或被停止。SWE-ReX 会立即抛出 `EnvironmentExpiredError`。如果频繁出现，增大 `environment.timeout_duration`。
+
+### `Error calculating cost for model`
+
+在 model 配置中添加 `cost_tracking: "ignore_errors"`。
+
+### `RuntimeError: SandboxTool sdt-xxx not found`
+
+在 [AGS 控制台](https://console.cloud.tencent.com/ags) 确认工具 ID、地域和工具状态。
+
+## 更新上游
+
+由于 overlay 是叠加在官方上游仓库上的，更新时只需：
+
+```bash
+make clean
+make setup
+```
+
+如果上游修改了 overlay 也修改的文件，可能需要更新 overlay 文件。详见 [overlay/OVERLAY.md](overlay/OVERLAY.md)。
+
+## 说明
+
+- 这不是官方的 mini-swe-agent 或 SWE-ReX 发布版本。
+- AGS 集成作为 Cookbook overlay 分发。
+- 上游项目：[SWE-agent/mini-SWE-agent](https://github.com/SWE-agent/mini-SWE-agent)、[SWE-agent/SWE-ReX](https://github.com/SWE-agent/SWE-ReX)

--- a/examples/mini-swe-agent/overlay/OVERLAY.md
+++ b/examples/mini-swe-agent/overlay/OVERLAY.md
@@ -1,0 +1,53 @@
+# Overlay File Reference
+
+This document lists every file in the `overlay/` directory, explains what it does, and whether it is a new file or replaces an existing upstream file.
+
+## SWE-ReX Overlay (`overlay/SWE-ReX/`)
+
+### New Files
+
+| File | Description |
+|------|-------------|
+| `src/swerex/deployment/ags.py` | `TencentAGSDeployment` — manages AGS sandbox instance lifecycle (create, connect, token refresh, destroy) |
+| `src/swerex/runtime/ags.py` | `AGSRuntime` — HTTP client for AGS data plane with `X-Access-Token` auth, SSL skip, and 404-to-`EnvironmentExpiredError` mapping |
+
+
+### Replaced Files
+
+| File | What Changed | Why |
+|------|-------------|-----|
+| `src/swerex/deployment/config.py` | Added `TencentAGSDeploymentConfig` class and added it to the `DeploymentConfig` union type | Registers AGS as a deployment backend so `get_deployment()` factory works |
+| `src/swerex/runtime/config.py` | Added `AGSRuntimeConfig` class and added it to the `RuntimeConfig` union type | Registers AGS as a runtime backend |
+| `src/swerex/exceptions.py` | Added `EnvironmentUnavailableError` and `EnvironmentExpiredError` | AGS runtime maps 404 responses to these exceptions for clean error handling |
+| `src/swerex/utils/log.py` | Added `set_console()`, `_get_console()`, and `set_stream_level()` functions | Allows batch runners to share a Console with Rich Live and control log verbosity |
+| `pyproject.toml` | Added `ags` extras: `tencentcloud-sdk-python-common`, `tencentcloud-sdk-python-ags` | Installs AGS SDK dependencies with `pip install swe-rex[ags]` |
+
+## mini-swe-agent Overlay (`overlay/mini-swe-agent/`)
+
+### New Files
+
+| File | Description |
+|------|-------------|
+| `src/minisweagent/environments/extra/swerex_ags.py` | `SwerexAgsEnvironment` — AGS environment wrapper that manages deployment lifecycle, executes commands, and handles credentials |
+| `src/minisweagent/config/benchmarks/swebench_ags.yaml` | AGS benchmark configuration template (prompt templates, timeouts, AGS endpoint defaults) |
+
+
+### Replaced Files
+
+| File | What Changed | Why |
+|------|-------------|-----|
+| `src/minisweagent/environments/__init__.py` | Added `"swerex_ags"` to the environment registry | Registers the AGS environment so it can be selected via config |
+| `src/minisweagent/utils/log.py` | Replaced direct `RichHandler` with `QueueHandler`/`QueueListener` pattern; added `setup_logging()`, `shutdown_logging()`, `set_stream_level()` | Prevents ABBA deadlock between `Handler._lock` and `Console._lock` when Rich Live is active in batch mode |
+| `src/minisweagent/run/benchmarks/swebench.py` | Added shared Console setup, SWE-ReX log level control, LiteLLM `suppress_debug_info`, AGS image name derivation, `shutdown_logging()` call | Thread-safe logging, deadlock prevention, AGS image support |
+| `src/minisweagent/run/benchmarks/utils/batch_progress.py` | `Lock` -> `RLock`, moved `renderables[1]` assignment inside lock, `print()` -> `logger.info()` | Fixes race conditions in progress display; avoids `print()` interfering with Rich Live |
+| `pyproject.toml` | Added `ags` extras: `swe-rex[ags]` | Installs AGS dependencies with `pip install mini-swe-agent[ags]` |
+
+## Potential Merge Conflicts
+
+When updating to a newer upstream, these files are most likely to have changed:
+
+- **`pyproject.toml`** (both repos) — dependency version bumps
+- **`swebench.py`** — batch runner is actively developed
+- **`config.py`** (SWE-ReX) — new deployment backends may be added
+
+New files (ags.py, swerex_ags.py, etc.) are unlikely to conflict since they are additions, not modifications.

--- a/examples/mini-swe-agent/overlay/SWE-ReX/pyproject.toml
+++ b/examples/mini-swe-agent/overlay/SWE-ReX/pyproject.toml
@@ -1,0 +1,256 @@
+[build-system]
+requires = ["setuptools"]  # REQUIRED if [build-system] table is used
+build-backend = "setuptools.build_meta"  # If not defined, then legacy behavior can happen.
+
+
+[project]
+name = "swe-rex"
+dynamic = ["version",]
+description = "Sandboxed code execution for AI agents, locally or on the cloud."
+readme = "README.md"
+requires-python = ">=3.10"
+license = {file = "LICENSE"}
+keywords = ["nlp", "agents", "code"]
+authors = [
+    {name = "Kilian Lieret", email = "kilian.lieret@posteo.de" },
+    {name = "Carlos E. Jimenez", email = "carlosej@princeton.edu" },
+    {name = "John Yang", email = "byjohnyang@gmail.com" }
+]
+
+# Classifiers help users find your project by categorizing it.
+classifiers = [
+  # How mature is this project? Common values are
+  #   3 - Alpha, 4 - Beta, 5 - Production/Stable
+  "Operating System :: OS Independent",
+  # Indicate who your project is intended for
+  "Intended Audience :: Developers",
+  # Pick your license as you wish
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3 :: Only",
+]
+
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "requests",
+    "pydantic>=2",
+    "pexpect",
+    "bashlex",
+    "python-multipart",
+    "rich",
+]
+
+[project.optional-dependencies]
+dev = [
+    "mike",
+    "mkdocs-material",
+    "mkdocs-glightbox",
+    "mkdocs-include-markdown-plugin",
+    "mkdocstrings[python]>=0.18",
+    "pytest",
+    "pytest-cov",
+    "pre-commit",
+    "pytest-asyncio",
+    "griffe-pydantic",
+    "swe-rex[modal]",
+    "swe-rex[fargate]",
+    "swe-rex[daytona]",
+]
+modal = [
+    "modal>=1.0",
+    "boto3",
+]
+fargate = [
+    "boto3",
+]
+daytona = [
+    "daytona",
+    "daytona-sdk >= 0.21",
+]
+ags = [
+    "tencentcloud-sdk-python-common",
+    "tencentcloud-sdk-python-ags",
+]
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.dynamic]
+version = {attr = "swerex.__version__"}
+
+[tool.setuptools.package-data]
+"pkgname" = ["py.typed"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+namespaces = false
+
+[project.urls]
+"Homepage" = "https://swe-rex.com"
+"Bug Reports" = "http://github.com/SWE-agent/SWE-rex/issues"
+"Documentation" = "https://swe-rex.com/latest/"
+"Source" = "http://github.com/SWE-agent/SWE-rex"
+
+[project.scripts]
+swerex-remote = "swerex.server:main"
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "cloud: mark tests for modal/fargate/etc.",
+]
+testpaths = [
+    "tests"
+]
+xfail_strict = false
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+
+[tool.ruff]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+    # ---- project specific ----
+    "tests/test_data",
+    # Exclude commands so they don't get the __future__ imports
+    "config/commands",
+]
+
+line-length = 120
+indent-width = 4
+
+target-version = "py310"
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+# I001: Isort, I002: required import
+select = [
+    # Error (E)
+    "E",
+    # Error (PLE)
+    "PLE",
+    # pycodestyle
+    "E713",  # not in
+    "E714",  # is not
+    "E711",  # comparison with None
+    # pyflakes
+    "F821",
+    "F822",
+    "F401",  # unused-import
+    "F841",  # unused var
+    "F541",  # f-string without args
+    "F901",  # raise NotImplemented should be raise NotImplementedError
+    # isort
+    "I001",  # isort
+    "I002",  # required import
+    # pyupgrade and related
+    "UP",    # pyupgrade
+    "C401",  # flake8-comprehensions: unnecessary-generator-set
+    "C402",  # flake8-comprehensions: unnecessary-generator-dict
+    "C403",  # flake8-comprehensions: unnecessary-list-comprehension-set
+    "C404",  # flake8-comprehensions: unnecessary-list-comprehension-dict
+    "C405",  # flake8-comprehensions: unnecessary-literal-set
+    "F632",  # pyflakes: is-literal
+    "W605",  # pycodestyle: invalid-escape-sequence
+    # bugbear
+    "B006",  # mutable default
+    "B007",  # unused loop var
+    "B009",  # getattr with constant
+    # flake8-errmsg
+    "EM",
+    # flake8-return
+    "RET",
+    # RUF
+    "RUF019",  # unneded key in dict check
+    # pytest
+    "PT",
+    # flake8-simplify (SIM)
+    "SIM201",
+    # flake8-use-pathlib
+    "PTH100",
+    "PTH110",
+    "PTH111",
+    "PTH112",
+    "PTH113",
+    "PTH114",
+    "PTH117",
+    "PTH118",
+    "PTH119",
+    "PTH120",
+    "PTH121",
+    "PTH122",
+    "PTH202",
+    "PTH203",
+    "PTH204",
+    "PTH205",
+]
+ignore = [
+    # flake8-return
+    "RET505",  # can't autofix
+    "RET506",  # can't autofix
+    "RET507",  # can't autofix
+    # error (E)
+    "E501",    # line too long
+    "E402",    # import not on top of file
+    "E722",    # bare except
+    "E741",    # ambiguous symbol
+    # pytest
+    "PT011",
+    "PT018",
+]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+[tool.typos.default.extend-identifiers]
+# *sigh* this just isn't worth the cost of fixing
+ACI = "ACI"
+
+[tool.typos.default.extend-words]
+# Don't correct the surname "Teh"
+aci = "aci"

--- a/examples/mini-swe-agent/overlay/SWE-ReX/src/swerex/deployment/ags.py
+++ b/examples/mini-swe-agent/overlay/SWE-ReX/src/swerex/deployment/ags.py
@@ -1,0 +1,349 @@
+"""Tencent AGS (Agent Sandbox) Deployment for SWE-ReX.
+
+This deployment manages SWE sandbox instances via Tencent Cloud AGS service.
+SWE sandbox has built-in swerex runtime, so no manual server installation is needed.
+
+Usage flow:
+    1. User creates a SWE sandbox tool on the AGS console (ToolType="swebench"), obtains a tool_id.
+    2. Provide tool_id + API credentials to create sandbox instances.
+    3. Each instance can use a different SWE-bench image.
+
+Requirements:
+    pip install tencentcloud-sdk-python-common tencentcloud-sdk-python-ags
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any
+
+from typing_extensions import Self
+
+from swerex.deployment.abstract import AbstractDeployment
+from swerex.deployment.config import TencentAGSDeploymentConfig
+from swerex.deployment.hooks.abstract import CombinedDeploymentHook, DeploymentHook
+from swerex.exceptions import DeploymentNotStartedError
+from swerex.runtime.abstract import IsAliveResponse
+from swerex.runtime.ags import AGSRuntime
+from swerex.utils.log import get_logger
+from swerex.utils.wait import _wait_until_alive
+
+if TYPE_CHECKING:
+    from tencentcloud.ags.v20250920 import ags_client
+
+__all__ = ["TencentAGSDeployment"]
+
+# Refresh token when it has less than this many seconds until expiration.
+TOKEN_REFRESH_THRESHOLD_SECONDS = 60
+
+
+@dataclass
+class TokenInfo:
+    """Token information with expiration tracking."""
+
+    token: str
+    expires_at: datetime
+    instance_id: str
+
+    def is_expired(self, threshold_seconds: int = TOKEN_REFRESH_THRESHOLD_SECONDS) -> bool:
+        """Check if token is expired or about to expire."""
+        now = datetime.now(timezone.utc)
+        return (self.expires_at - now).total_seconds() < threshold_seconds
+
+
+class TencentAGSDeployment(AbstractDeployment):
+    """Deployment for Tencent Cloud AGS SWE Sandbox.
+
+    Creates and manages SWE sandbox instances that have a built-in swerex
+    runtime. The deployment lifecycle:
+
+    1. Verify the user-provided SWE sandbox tool (tool_id) exists and is ACTIVE.
+    2. Start a sandbox instance, optionally overriding the image.
+    3. Acquire an access token for the instance.
+    4. Connect an ``AGSRuntime`` to the instance endpoint.
+    5. Wait for the runtime to become alive.
+    """
+
+    def __init__(
+        self,
+        *,
+        logger: logging.Logger | None = None,
+        **kwargs: Any,
+    ):
+        """Initialize Tencent AGS Deployment.
+
+        Args:
+            logger: Logger instance.
+            **kwargs: Keyword arguments (see ``TencentAGSDeploymentConfig``).
+        """
+        self._config = TencentAGSDeploymentConfig(**kwargs)
+        self._runtime: AGSRuntime | None = None
+        self._instance_id: str | None = None
+        self._token_info: TokenInfo | None = None
+        self.logger = logger or get_logger("rex-deploy")
+        self._hooks = CombinedDeploymentHook()
+
+    def add_hook(self, hook: DeploymentHook) -> None:
+        self._hooks.add_hook(hook)
+
+    @classmethod
+    def from_config(cls, config: TencentAGSDeploymentConfig) -> Self:
+        return cls(**config.model_dump())
+
+    # ==================== SDK Client ====================
+
+    def _get_client(self) -> "ags_client.AgsClient":
+        """Create a synchronous AGS client instance."""
+        from tencentcloud.ags.v20250920 import ags_client
+        from tencentcloud.common import credential
+        from tencentcloud.common.profile.client_profile import ClientProfile
+        from tencentcloud.common.profile.http_profile import HttpProfile
+
+        cred = credential.Credential(self._config.secret_id, self._config.secret_key)
+
+        http_profile = HttpProfile()
+        http_profile.endpoint = self._config.http_endpoint
+
+        client_profile = ClientProfile()
+        client_profile.httpProfile = http_profile
+        if self._config.skip_ssl_verify:
+            client_profile.unsafeSkipVerify = True
+
+        return ags_client.AgsClient(cred, self._config.region, client_profile)
+
+    # ==================== Token Management ====================
+
+    def _acquire_ags_token(self, instance_id: str) -> TokenInfo:
+        """Acquire a new token for the given instance (synchronous SDK call)."""
+        from tencentcloud.ags.v20250920 import models
+
+        client = self._get_client()
+        token_req = models.AcquireSandboxInstanceTokenRequest()
+        token_req.InstanceId = instance_id
+        token_resp = client.AcquireSandboxInstanceToken(token_req)
+
+        expires_at = self._parse_timestamp(token_resp.ExpiresAt)
+        return TokenInfo(token=token_resp.Token, expires_at=expires_at, instance_id=instance_id)
+
+    def _parse_timestamp(self, timestamp_str: str) -> datetime:
+        """Parse timestamp string to datetime, with multiple format fallbacks."""
+        # ISO 8601 format
+        try:
+            if timestamp_str.endswith("Z"):
+                timestamp_str = timestamp_str[:-1] + "+00:00"
+            dt = datetime.fromisoformat(timestamp_str)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+        except ValueError:
+            pass
+
+        # Unix timestamp
+        try:
+            return datetime.fromtimestamp(float(timestamp_str), tz=timezone.utc)
+        except ValueError:
+            pass
+
+        # Fallback: assume 1 hour from now
+        self.logger.warning("Could not parse timestamp %s, assuming 1 hour expiration", timestamp_str)
+        return datetime.now(timezone.utc) + timedelta(hours=1)
+
+    async def _ensure_valid_token(self) -> str:
+        """Ensure token is valid, refresh if needed. Returns the valid token."""
+        if self._token_info is None:
+            raise DeploymentNotStartedError()
+
+        if not self._token_info.is_expired():
+            return self._token_info.token
+
+        self.logger.info("Token expired or about to expire, refreshing...")
+        self._token_info = await asyncio.to_thread(self._acquire_ags_token, self._token_info.instance_id)
+        return self._token_info.token
+
+    # ==================== Tool Verification ====================
+
+    def _verify_tool_exists(self, tool_id: str) -> None:
+        """Verify that a SandboxTool exists and is ACTIVE.
+
+        Raises:
+            RuntimeError: If the tool does not exist or is not ACTIVE.
+        """
+        from tencentcloud.ags.v20250920 import models
+
+        client = self._get_client()
+        describe_req = models.DescribeSandboxToolListRequest()
+        describe_req.ToolIds = [tool_id]
+        describe_resp = client.DescribeSandboxToolList(describe_req)
+
+        if not describe_resp.SandboxToolSet:
+            raise RuntimeError(f"SandboxTool {tool_id} not found")
+
+        status = describe_resp.SandboxToolSet[0].Status
+        if status != "ACTIVE":
+            raise RuntimeError(f"SandboxTool {tool_id} is not ACTIVE (status: {status})")
+
+        tool_type = describe_resp.SandboxToolSet[0].ToolType
+        if tool_type != "swebench":
+            self.logger.warning(f"SandboxTool {tool_id} is type '{tool_type}', expected 'swebench'")
+
+        self.logger.info(f"Verified SWE SandboxTool {tool_id} exists and is ACTIVE")
+
+    # ==================== Lifecycle ====================
+
+    async def is_alive(self, *, timeout: float | None = None) -> IsAliveResponse:
+        """Check if the runtime is alive."""
+        if self._runtime is None or self._instance_id is None:
+            raise DeploymentNotStartedError()
+
+        await self._ensure_valid_token()
+
+        # Verify instance is still running
+        from tencentcloud.ags.v20250920 import models
+
+        client = self._get_client()
+        describe_req = models.DescribeSandboxInstanceListRequest()
+        describe_req.InstanceIds = [self._instance_id]
+        describe_resp = await asyncio.to_thread(client.DescribeSandboxInstanceList, describe_req)
+
+        if not describe_resp.InstanceSet:
+            raise RuntimeError(f"SandboxInstance {self._instance_id} not found")
+
+        instance_status = describe_resp.InstanceSet[0].Status
+        if instance_status != "RUNNING":
+            raise RuntimeError(f"SandboxInstance is not running: {instance_status}")
+
+        return await self._runtime.is_alive(timeout=timeout)
+
+    async def _wait_until_alive(self, timeout: float) -> None:
+        """Wait until the runtime is alive."""
+        return await _wait_until_alive(self.is_alive, timeout=timeout, function_timeout=self._config.runtime_timeout)
+
+    async def start(self) -> None:
+        """Start a SWE sandbox instance and connect the runtime.
+
+        Steps:
+            1. Verify the SWE sandbox tool exists.
+            2. Start a sandbox instance (with optional image override).
+            3. Acquire an access token.
+            4. Create AGSRuntime connected to the instance.
+            5. Wait for the runtime to become alive.
+        """
+        if self._runtime is not None and self._instance_id is not None:
+            self.logger.warning("Deployment is already started. Ignoring duplicate start() call.")
+            return
+
+        if not self._config.tool_id:
+            raise ValueError(
+                "tool_id is required. Please create a SWE sandbox tool on the AGS console first "
+                "and provide its ID."
+            )
+
+        self.logger.info("Starting Tencent AGS SWE sandbox...")
+        self._hooks.on_custom_step("Creating SWE sandbox")
+
+        # Step 1: Verify tool exists
+        t0 = time.time()
+        await asyncio.to_thread(self._verify_tool_exists, self._config.tool_id)
+        self.logger.info(f"Using SWE tool ID: {self._config.tool_id}")
+
+        # Step 2: Start sandbox instance
+        from tencentcloud.ags.v20250920 import models
+
+        client = self._get_client()
+        req = models.StartSandboxInstanceRequest()
+        req.ToolId = self._config.tool_id
+        req.ClientToken = str(uuid.uuid4())
+
+        if self._config.timeout:
+            req.Timeout = self._config.timeout
+
+        # Override image at instance creation time
+        if self._config.image:
+            req.CustomConfiguration = models.CustomConfiguration()
+            req.CustomConfiguration.Image = self._config.image
+            req.CustomConfiguration.ImageRegistryType = "system"
+            self.logger.info(f"Using SWE image: {self._config.image}")
+
+        self.logger.debug(f"StartSandboxInstance request: ToolId={req.ToolId}")
+        resp = await asyncio.to_thread(client.StartSandboxInstance, req)
+        self._instance_id = resp.Instance.InstanceId
+
+        if not self._instance_id:
+            raise RuntimeError(f"Failed to get instance ID from response: {resp}")
+
+        elapsed_creation = time.time() - t0
+        self.logger.info(f"SWE sandbox instance {self._instance_id} is RUNNING in {elapsed_creation:.2f}s")
+
+        # Step 3: Acquire token
+        self._token_info = await asyncio.to_thread(self._acquire_ags_token, self._instance_id)
+
+        # Step 4: Build endpoint URL and create runtime
+        # Use HTTPS with the configured data-gateway port encoded in the hostname.
+        # The Host header ({port}-{instanceId}.{domain}) routes traffic via data-gateway.
+        endpoint = f"https://{self._config.port}-{self._instance_id}.{self._config.domain}"
+        self.logger.info(f"SWE sandbox endpoint: {endpoint}")
+        self.logger.debug(
+            f"AGS token acquired, expires_at: {self._token_info.expires_at}"
+        )
+
+        self._hooks.on_custom_step("Connecting to runtime")
+        self._runtime = AGSRuntime(
+            host=endpoint,
+            port=None,
+            ags_token=self._token_info.token,
+            auth_token="",  # SWE sandbox doesn't require swerex auth token
+            timeout=self._config.runtime_timeout,
+            skip_ssl_verify=self._config.skip_ssl_verify,
+            logger=self.logger,
+            token_refresher=self._ensure_valid_token,
+        )
+
+        # Step 5: Wait for runtime to be ready
+        remaining_timeout = max(0, self._config.startup_timeout - elapsed_creation)
+        t1 = time.time()
+        await self._wait_until_alive(timeout=remaining_timeout)
+        self.logger.info(f"Runtime connected in {time.time() - t1:.2f}s")
+
+    async def stop(self) -> None:
+        """Stop the runtime and the AGS sandbox instance."""
+        if self._runtime is not None:
+            try:
+                await self._runtime.close()
+            except Exception:
+                pass
+            self._runtime = None
+
+        if self._instance_id is not None:
+            try:
+                from tencentcloud.ags.v20250920 import models
+
+                client = self._get_client()
+                stop_req = models.StopSandboxInstanceRequest()
+                stop_req.InstanceId = self._instance_id
+                await asyncio.to_thread(client.StopSandboxInstance, stop_req)
+            except Exception:
+                pass
+
+        self._instance_id = None
+        self._token_info = None
+
+    @property
+    def runtime(self) -> AGSRuntime:
+        """Returns the runtime if running.
+
+        Raises:
+            DeploymentNotStartedError: If the deployment was not started.
+        """
+        if self._runtime is None:
+            raise DeploymentNotStartedError()
+        return self._runtime
+
+    @property
+    def instance_id(self) -> str | None:
+        """Returns the AGS sandbox instance ID."""
+        return self._instance_id

--- a/examples/mini-swe-agent/overlay/SWE-ReX/src/swerex/deployment/config.py
+++ b/examples/mini-swe-agent/overlay/SWE-ReX/src/swerex/deployment/config.py
@@ -1,0 +1,289 @@
+from pathlib import PurePath
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from swerex.deployment.abstract import AbstractDeployment
+
+
+class LocalDeploymentConfig(BaseModel):
+    """Configuration for running locally."""
+
+    type: Literal["local"] = "local"
+    """Discriminator for (de)serialization/CLI. Do not change."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    def get_deployment(self) -> AbstractDeployment:
+        from swerex.deployment.local import LocalDeployment
+
+        return LocalDeployment.from_config(self)
+
+
+class DockerDeploymentConfig(BaseModel):
+    """Configuration for running locally in a Docker or Podman container."""
+
+    image: str = "python:3.11"
+    """The name of the container image to use."""
+    port: int | None = None
+    """The port that the container connects to. If None, a free port is found."""
+    docker_args: list[str] = []
+    """Additional arguments to pass to the container run command. If --platform is specified here, it will be moved to the platform field."""
+    startup_timeout: float = 180.0
+    """The time to wait for the runtime to start."""
+    pull: Literal["never", "always", "missing"] = "missing"
+    """When to pull container images."""
+    remove_images: bool = False
+    """Whether to remove the image after it has stopped."""
+    python_standalone_dir: str | None = None
+    """The directory to use for the python standalone."""
+    platform: str | None = None
+    """The platform to use for the container image."""
+    remove_container: bool = True
+    """Whether to remove the container after it has stopped."""
+    container_runtime: Literal["docker", "podman"] = "docker"
+    """The container runtime to use (docker or podman)."""
+    exec_shell: list[str] = ["/bin/sh", "-c"]
+    """The shell executable and arguments to use for running commands."""
+    docker_internal_host: str = "http://127.0.0.1"
+    """The host to use for connecting to the runtime.
+    In most cases you can leave this as-is, however for docker-in-docker
+    setups you might have to set it to http://host.docker.internal/ 
+    (see https://github.com/SWE-agent/SWE-ReX/issues/253 for more information).
+    """
+
+    type: Literal["docker"] = "docker"
+    """Discriminator for (de)serialization/CLI. Do not change."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="before")
+    def validate_platform_args(cls, data: dict) -> dict:
+        if not isinstance(data, dict):
+            return data
+
+        docker_args = data.get("docker_args", [])
+        platform = data.get("platform")
+
+        platform_arg_idx = next((i for i, arg in enumerate(docker_args) if arg.startswith("--platform")), -1)
+
+        if platform_arg_idx != -1:
+            if platform is not None:
+                msg = "Cannot specify platform both via 'platform' field and '--platform' in docker_args"
+                raise ValueError(msg)
+            # Extract platform value from --platform argument
+            if "=" in docker_args[platform_arg_idx]:
+                # Handle case where platform is specified as --platform=value
+                data["platform"] = docker_args[platform_arg_idx].split("=", 1)[1]
+                data["docker_args"] = docker_args[:platform_arg_idx] + docker_args[platform_arg_idx + 1 :]
+            elif platform_arg_idx + 1 < len(docker_args):
+                data["platform"] = docker_args[platform_arg_idx + 1]
+                # Remove the --platform and its value from docker_args
+                data["docker_args"] = docker_args[:platform_arg_idx] + docker_args[platform_arg_idx + 2 :]
+            else:
+                msg = "--platform argument must be followed by a value"
+                raise ValueError(msg)
+
+        return data
+
+    def get_deployment(self) -> AbstractDeployment:
+        from swerex.deployment.docker import DockerDeployment
+
+        return DockerDeployment.from_config(self)
+
+
+class ModalDeploymentConfig(BaseModel):
+    """Configuration for running on Modal."""
+
+    image: str | PurePath = "python:3.11"
+    """Image to use for the deployment."""
+
+    startup_timeout: float = 180.0
+    """The time to wait for the runtime to start."""
+
+    runtime_timeout: float = 60.0
+    """Runtime timeout (default timeout for all runtime requests)
+    """
+
+    deployment_timeout: float = 3600.0
+    """Kill deployment after this many seconds no matter what.
+    This is a useful killing switch to ensure that you don't spend too 
+    much money on modal.
+    """
+
+    modal_sandbox_kwargs: dict[str, Any] = {}
+    """Additional arguments to pass to `modal.Sandbox.create`"""
+
+    type: Literal["modal"] = "modal"
+    """Discriminator for (de)serialization/CLI. Do not change."""
+
+    install_pipx: bool = True
+    """Whether to install pipx with apt in the container.
+    This is enabled by default so we can fall back to installing swe-rex
+    with pipx if the image does not have it. However, depending on your image,
+    installing pipx might fail (or be slow).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    def get_deployment(self) -> AbstractDeployment:
+        from swerex.deployment.modal import ModalDeployment
+
+        return ModalDeployment.from_config(self)
+
+
+class FargateDeploymentConfig(BaseModel):
+    """Configuration for running on AWS Fargate."""
+
+    image: str = "python:3.11"
+    port: int = 8880
+    cluster_name: str = "swe-rex-cluster"
+    execution_role_prefix: str = "swe-rex-execution-role"
+    task_definition_prefix: str = "swe-rex-task"
+    log_group: str | None = "/ecs/swe-rex-deployment"
+    security_group_prefix: str = "swe-rex-deployment-sg"
+    fargate_args: dict[str, str] = {}
+    container_timeout: float = 60 * 15
+    runtime_timeout: float = 60
+
+    type: Literal["fargate"] = "fargate"
+    """Discriminator for (de)serialization/CLI. Do not change."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    def get_deployment(self) -> AbstractDeployment:
+        from swerex.deployment.fargate import FargateDeployment
+
+        return FargateDeployment.from_config(self)
+
+
+class RemoteDeploymentConfig(BaseModel):
+    """Configuration for `RemoteDeployment`, a wrapper around `RemoteRuntime` that can be used to connect to any
+    swerex server.
+    """
+
+    auth_token: str
+    """The token to use for authentication."""
+    host: str = "http://127.0.0.1"
+    """The host to connect to."""
+    port: int | None = None
+    """The port to connect to."""
+    timeout: float = 0.15
+
+    type: Literal["remote"] = "remote"
+    """Discriminator for (de)serialization/CLI. Do not change."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    def get_deployment(self) -> AbstractDeployment:
+        from swerex.deployment.remote import RemoteDeployment
+
+        return RemoteDeployment.from_config(self)
+
+
+class DummyDeploymentConfig(BaseModel):
+    """Configuration for `DummyDeployment`, a deployment that is used for testing."""
+
+    type: Literal["dummy"] = "dummy"
+    """Discriminator for (de)serialization/CLI. Do not change."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    def get_deployment(self) -> AbstractDeployment:
+        from swerex.deployment.dummy import DummyDeployment
+
+        return DummyDeployment.from_config(self)
+
+
+class DaytonaDeploymentConfig(BaseModel):
+    """Configuration for Daytona deployment."""
+
+    api_key: str = Field(default="", description="Daytona API key for authentication")
+    target: str = Field(default="us", description="Daytona target region (us, eu, etc.)")
+    port: int = Field(default=8000, description="Port to expose for the SWE Rex server")
+    container_timeout: float = Field(default=60 * 15, description="Timeout for the container")
+    runtime_timeout: float = Field(default=60, description="Timeout for the runtime")
+    image: str = Field(default="python:3.11", description="Image to use for the sandbox")
+
+    def get_deployment(self) -> AbstractDeployment:
+        from swerex.deployment.daytona import DaytonaDeployment
+
+        return DaytonaDeployment.from_config(self)
+
+
+class TencentAGSDeploymentConfig(BaseModel):
+    """Configuration for Tencent Cloud AGS (Agent Sandbox) SWE sandbox deployment.
+
+    Usage flow:
+        1. Create a SWE sandbox tool on the AGS console (ToolType="swebench") to get a tool_id.
+        2. Provide tool_id + API credentials here.
+        3. Each instance can override the image with a SWE-bench dataset image.
+    """
+
+    type: Literal["tencentags"] = "tencentags"
+    """Discriminator for (de)serialization/CLI. Do not change."""
+
+    secret_id: str = Field(default="", description="Tencent Cloud SecretId (or use TENCENTCLOUD_SECRET_ID env var)")
+    secret_key: str = Field(default="", description="Tencent Cloud SecretKey (or use TENCENTCLOUD_SECRET_KEY env var)")
+    http_endpoint: str = Field(default="ags.tencentcloudapi.com", description="Tencent Cloud HTTP endpoint")
+    skip_ssl_verify: bool = Field(default=False, description="Skip SSL certificate verification")
+    region: str = Field(default="ap-chongqing", description="Region for AGS service")
+    domain: str = Field(default="", description="Domain for sandbox endpoint. Auto-derived from region if empty.")
+
+    tool_id: str = Field(default="", description="SWE SandboxTool ID (created on AGS console)")
+
+    image: str = Field(
+        default="",
+        description="SWE image name for instance override (e.g., 'swebench/sweb.eval.x86_64.xxx:latest')",
+    )
+
+    timeout: str = Field(default="1h", description="Sandbox instance timeout (e.g., '5m', '300s', '1h')")
+    port: int = Field(default=8000, description="Port for sandbox endpoint (default SWE sandbox port)")
+    startup_timeout: float = Field(default=300.0, description="Time to wait for runtime to start")
+    runtime_timeout: float = Field(default=60.0, description="Timeout for runtime requests")
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="before")
+    def validate_credentials(cls, data: dict) -> dict:
+        """Allow credentials from environment variables as fallback."""
+        import os
+
+        if not isinstance(data, dict):
+            return data
+
+        if not data.get("secret_id"):
+            data["secret_id"] = os.environ.get("TENCENTCLOUD_SECRET_ID", "")
+        if not data.get("secret_key"):
+            data["secret_key"] = os.environ.get("TENCENTCLOUD_SECRET_KEY", "")
+
+        # Auto-derive domain from region if not explicitly set
+        if not data.get("domain"):
+            region = data.get("region", "ap-chongqing")
+            data["domain"] = f"{region}.tencentags.com"
+
+        return data
+
+    def get_deployment(self) -> AbstractDeployment:
+        from swerex.deployment.ags import TencentAGSDeployment
+
+        return TencentAGSDeployment.from_config(self)
+
+
+DeploymentConfig = (
+    LocalDeploymentConfig
+    | DockerDeploymentConfig
+    | ModalDeploymentConfig
+    | FargateDeploymentConfig
+    | RemoteDeploymentConfig
+    | DummyDeploymentConfig
+    | DaytonaDeploymentConfig
+    | TencentAGSDeploymentConfig
+)
+"""Union of all deployment configurations. Useful for type hints."""
+
+
+def get_deployment(
+    config: DeploymentConfig,
+) -> AbstractDeployment:
+    return config.get_deployment()

--- a/examples/mini-swe-agent/overlay/SWE-ReX/src/swerex/exceptions.py
+++ b/examples/mini-swe-agent/overlay/SWE-ReX/src/swerex/exceptions.py
@@ -1,0 +1,60 @@
+from typing import Any
+
+
+class SwerexException(Exception):
+    """Any exception that is raised by SWE-Rex."""
+
+
+class SessionNotInitializedError(SwerexException, RuntimeError):
+    """Raised if we try to run a command in a shell that is not initialized."""
+
+
+class NonZeroExitCodeError(SwerexException, RuntimeError):
+    """Can be raised if we execute a command in the shell and it has a non-zero exit code."""
+
+
+class BashIncorrectSyntaxError(SwerexException, RuntimeError):
+    """Before running a bash command, we check for syntax errors.
+    This is the error message for those syntax errors.
+    """
+
+    def __init__(self, message: str, *, extra_info: dict[str, Any] | None = None):
+        super().__init__(message)
+        if extra_info is None:
+            extra_info = {}
+        self.extra_info = extra_info
+
+
+class CommandTimeoutError(SwerexException, RuntimeError, TimeoutError): ...
+
+
+class NoExitCodeError(SwerexException, RuntimeError): ...
+
+
+class SessionExistsError(SwerexException, ValueError): ...
+
+
+class SessionDoesNotExistError(SwerexException, ValueError): ...
+
+
+class DeploymentNotStartedError(SwerexException, RuntimeError):
+    def __init__(self, message="Deployment not started"):
+        super().__init__(message)
+
+
+class DeploymentStartupError(SwerexException, RuntimeError): ...
+
+
+class DockerPullError(DeploymentStartupError): ...
+
+
+class EnvironmentUnavailableError(SwerexException, RuntimeError):
+    """Raised when the backing execution environment is no longer usable."""
+
+
+class EnvironmentExpiredError(EnvironmentUnavailableError, TimeoutError):
+    """Raised when the backing sandbox instance has expired or disappeared."""
+
+
+class DummyOutputsExhaustedError(SwerexException, RuntimeError):
+    """Raised if we try to pop from the dummy runtime's run_in_session_outputs list, but it's empty."""

--- a/examples/mini-swe-agent/overlay/SWE-ReX/src/swerex/runtime/ags.py
+++ b/examples/mini-swe-agent/overlay/SWE-ReX/src/swerex/runtime/ags.py
@@ -1,0 +1,192 @@
+"""Tencent AGS (Agent Sandbox) Runtime for SWE-ReX.
+
+This runtime connects to Tencent Cloud AGS SWE sandbox instances.
+It extends RemoteRuntime with AGS-specific authentication (X-Access-Token header)
+and automatic token refresh support.
+
+Requirements:
+    pip install aiohttp
+"""
+
+from __future__ import annotations
+
+import logging
+import ssl
+from typing import Any, Awaitable, Callable
+
+import aiohttp
+from pydantic import BaseModel
+from typing_extensions import Self
+
+from swerex.exceptions import EnvironmentExpiredError
+from swerex.runtime.abstract import IsAliveResponse, _ExceptionTransfer
+from swerex.runtime.remote import RemoteRuntime
+from swerex.utils.log import get_logger
+
+__all__ = ["AGSRuntime"]
+
+# Type alias for the token refresher callback.
+TokenRefresher = Callable[[], Awaitable[str]]
+
+
+class AGSRuntime(RemoteRuntime):
+    """Runtime for Tencent AGS (Agent Sandbox) SWE sandbox.
+
+    Extends RemoteRuntime with:
+    - X-Access-Token header for AGS gateway authentication
+    - Automatic token refresh via a callback
+    - SSL verification skip support for internal endpoints
+    """
+
+    def __init__(
+        self,
+        *,
+        logger: logging.Logger | None = None,
+        token_refresher: TokenRefresher | None = None,
+        **kwargs: Any,
+    ):
+        """Initialize AGS Runtime.
+
+        Args:
+            logger: Logger instance.
+            token_refresher: Async callback that returns a fresh AGS token.
+                Called automatically before each request when the token may be expired.
+            **kwargs: Keyword arguments (see ``AGSRuntimeConfig`` for details).
+        """
+        from swerex.runtime.config import AGSRuntimeConfig
+
+        self._config = AGSRuntimeConfig(**kwargs)
+        self._token_refresher = token_refresher
+        self.logger = logger or get_logger("rex-runtime")
+        if not self._config.host.startswith("http"):
+            self.logger.warning("Host %s does not start with http, adding https://", self._config.host)
+            self._config.host = f"https://{self._config.host}"
+
+    @classmethod
+    def from_config(cls, config: Any) -> Self:
+        return cls(**config.model_dump())
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        """Build request headers with AGS token authentication."""
+        headers: dict[str, str] = {}
+        if self._config.ags_token:
+            headers["X-Access-Token"] = self._config.ags_token
+        if self._config.auth_token:
+            headers["X-API-Key"] = self._config.auth_token
+        return headers
+
+    @property
+    def _ssl_param(self) -> ssl.SSLContext | None:
+        """Get SSL context.
+
+        Returns a permissive SSL context when verification is disabled,
+        otherwise ``None`` for default behavior.
+        """
+        if self._config.skip_ssl_verify:
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            return ctx
+        return None
+
+    async def _ensure_valid_token(self) -> None:
+        """Refresh the AGS token via the callback if one is configured."""
+        if self._token_refresher is not None:
+            new_token = await self._token_refresher()
+            self._config.ags_token = new_token
+
+    def _classify_request_exception(self, exception: Exception, request_url: str) -> Exception:
+        """Map AGS gateway errors to more actionable environment exceptions."""
+        if isinstance(exception, EnvironmentExpiredError):
+            return exception
+        if isinstance(exception, aiohttp.ClientResponseError) and exception.status == 404:
+            return EnvironmentExpiredError(
+                f"AGS sandbox runtime endpoint disappeared: {request_url}. "
+                "The sandbox instance likely expired or was stopped."
+            )
+        return exception
+
+    async def _handle_response_errors(self, response: aiohttp.ClientResponse) -> None:
+        """Raise exceptions found in the request response.
+
+        Extends the parent to treat 404 as ``EnvironmentExpiredError``
+        (the AGS sandbox likely expired or was stopped).
+        """
+        if response.status == 511:
+            data = await response.json()
+            exc_transfer = _ExceptionTransfer(**data["swerexception"])
+            self._handle_transfer_exception(exc_transfer)
+        elif response.status == 404:
+            try:
+                data = await response.json()
+            except Exception:
+                data = {}
+            message = data.get("message") or data.get("error") or "The requested resource does not exist"
+            raise EnvironmentExpiredError(
+                f"AGS sandbox runtime endpoint returned 404: {message}. "
+                "The sandbox instance likely expired or was stopped."
+            )
+        if response.status >= 400:
+            response.raise_for_status()
+
+    # ------------------------------------------------------------------
+    # Override is_alive / _request only to inject token refresh + SSL.
+    # No logging here — errors propagate as exceptions to the caller.
+    # ------------------------------------------------------------------
+
+    async def is_alive(self, *, timeout: float | None = None) -> IsAliveResponse:
+        """Check if the runtime is alive, refreshing the token first."""
+        await self._ensure_valid_token()
+        url = f"{self._api_url}/is_alive"
+        try:
+            async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(force_close=True)) as session:
+                timeout_value = self._get_timeout(timeout)
+                async with session.get(
+                    url,
+                    headers=self._headers,
+                    timeout=aiohttp.ClientTimeout(total=timeout_value),
+                    ssl=self._ssl_param,
+                ) as response:
+                    if response.status == 200:
+                        data = await response.json()
+                        return IsAliveResponse(**data)
+                    elif response.status == 511:
+                        data = await response.json()
+                        exc_transfer = _ExceptionTransfer(**data["swerexception"])
+                        self._handle_transfer_exception(exc_transfer)
+
+                    try:
+                        body = await response.text()
+                    except Exception:
+                        body = "<could not read response body>"
+                    msg = f"GET {url} returned status {response.status}. Body (first 500 chars): {body[:500]}"
+                    return IsAliveResponse(is_alive=False, message=msg)
+        except aiohttp.ClientError as e:
+            return IsAliveResponse(is_alive=False, message=f"Connection error to {url}: {e}")
+        except Exception as e:
+            return IsAliveResponse(is_alive=False, message=f"Unexpected error connecting to {url}: {e}")
+
+    async def _request(self, endpoint: str, payload: BaseModel | None, output_class: Any, num_retries: int = 0):
+        """Make a request with automatic token refresh and SSL skip.
+
+        No retry loop here (default ``num_retries=0``).  Exceptions are
+        classified into AGS-specific types before re-raising so the caller
+        gets actionable errors (e.g. ``EnvironmentExpiredError``).
+        """
+        await self._ensure_valid_token()
+        request_url = f"{self._api_url}/{endpoint}"
+        try:
+            async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(force_close=True)) as session:
+                timeout_value = self._get_timeout(None)
+                async with session.post(
+                    request_url,
+                    json=payload.model_dump() if payload else None,
+                    headers=self._headers,
+                    timeout=aiohttp.ClientTimeout(total=timeout_value),
+                    ssl=self._ssl_param,
+                ) as resp:
+                    await self._handle_response_errors(resp)
+                    return output_class(**await resp.json())
+        except Exception as e:
+            raise self._classify_request_exception(e, request_url) from e

--- a/examples/mini-swe-agent/overlay/SWE-ReX/src/swerex/runtime/config.py
+++ b/examples/mini-swe-agent/overlay/SWE-ReX/src/swerex/runtime/config.py
@@ -1,0 +1,92 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from swerex.runtime.abstract import AbstractRuntime
+
+
+class LocalRuntimeConfig(BaseModel):
+    """Configuration for a local runtime."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["local"] = "local"
+    """Discriminator for (de)serialization/CLI. Do not change."""
+
+    def get_runtime(self) -> AbstractRuntime:
+        from swerex.runtime.local import LocalRuntime
+
+        return LocalRuntime.from_config(self)
+
+
+class RemoteRuntimeConfig(BaseModel):
+    auth_token: str
+    """The token to use for authentication."""
+    host: str = "http://127.0.0.1"
+    """The host to connect to."""
+    port: int | None = None
+    """The port to connect to."""
+    timeout: float = 0.15
+    """The timeout for the runtime."""
+
+    type: Literal["remote"] = "remote"
+    """Discriminator for (de)serialization/CLI. Do not change."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    def get_runtime(self) -> AbstractRuntime:
+        from swerex.runtime.remote import RemoteRuntime
+
+        return RemoteRuntime.from_config(self)
+
+
+class DummyRuntimeConfig(BaseModel):
+    """Configuration for a dummy runtime."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["dummy"] = "dummy"
+    """Discriminator for (de)serialization/CLI. Do not change."""
+
+    def get_runtime(self) -> AbstractRuntime:
+        from swerex.runtime.dummy import DummyRuntime
+
+        return DummyRuntime.from_config(self)
+
+
+class AGSRuntimeConfig(BaseModel):
+    """Configuration for Tencent AGS (Agent Sandbox) runtime.
+
+    Used to connect to SWE sandbox instances via AGS gateway.
+    Authentication uses X-Access-Token header instead of X-API-Key.
+    """
+
+    auth_token: str = ""
+    """The token for SWE-ReX server authentication (X-API-Key)."""
+    ags_token: str = ""
+    """The access token for AGS gateway authentication (X-Access-Token)."""
+    host: str = "https://127.0.0.1"
+    """The host URL to connect to (e.g., 'https://8000-instance-id.domain.com')."""
+    port: int | None = None
+    """The port to connect to. Usually None since port is embedded in AGS URLs."""
+    timeout: float = 60.0
+    """The timeout for runtime requests."""
+    skip_ssl_verify: bool = False
+    """Skip SSL certificate verification for runtime requests."""
+
+    type: Literal["ags"] = "ags"
+    """Discriminator for (de)serialization/CLI. Do not change."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    def get_runtime(self) -> AbstractRuntime:
+        from swerex.runtime.ags import AGSRuntime
+
+        return AGSRuntime.from_config(self)
+
+
+RuntimeConfig = LocalRuntimeConfig | RemoteRuntimeConfig | DummyRuntimeConfig | AGSRuntimeConfig
+
+
+def get_runtime(config: RuntimeConfig) -> AbstractRuntime:
+    return config.get_runtime()

--- a/examples/mini-swe-agent/overlay/SWE-ReX/src/swerex/utils/log.py
+++ b/examples/mini-swe-agent/overlay/SWE-ReX/src/swerex/utils/log.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import logging
+import os
+import threading
+
+from rich.console import Console
+from rich.logging import RichHandler
+from rich.text import Text
+
+_SET_UP_LOGGERS = set()
+_ADDITIONAL_HANDLERS = []
+
+# Console instance used by all SWE-ReX loggers.
+# Defaults to a dedicated stderr Console. Call ``set_console()`` *before* the
+# first ``get_logger()`` call to share a Console with Rich Live and avoid
+# garbled output in batch mode.
+_swerex_logging_console: Console | None = None
+
+
+def set_console(console: Console) -> None:
+    """Override the Console used by all future ``get_logger()`` calls.
+
+    Call this early (before any SWE-ReX logger is created) to share a single
+    Console with Rich ``Live``, so that log output is rendered above the Live
+    area instead of clobbering it.
+    """
+    global _swerex_logging_console
+    _swerex_logging_console = console
+
+
+def _get_console() -> Console:
+    """Return the current logging Console, creating a default if needed."""
+    global _swerex_logging_console
+    if _swerex_logging_console is None:
+        _swerex_logging_console = Console(stderr=True)
+    return _swerex_logging_console
+
+
+def _interpret_level_from_env(level: str | None, *, default=logging.DEBUG) -> int:
+    if not level:
+        return default
+    level = level.strip()
+    if not level:
+        return default
+    try:
+        return int(level)
+    except ValueError:
+        interpreted_level = getattr(logging, level.upper(), None)
+        if isinstance(interpreted_level, int):
+            return interpreted_level
+        return default
+
+
+_STREAM_LEVEL = _interpret_level_from_env(os.environ.get("SWE_REX_LOG_STREAM_LEVEL"))
+_INCLUDE_LOGGER_NAME_IN_STREAM_HANDLER = False
+
+
+def set_stream_level(level: int) -> None:
+    """Change the stream (RichHandler) level for all existing and future SWE-ReX loggers.
+
+    Call this in batch mode to reduce console noise while Rich Live is active.
+    """
+    global _STREAM_LEVEL
+    _STREAM_LEVEL = level
+    for name in list(_SET_UP_LOGGERS):
+        logger = logging.getLogger(name)
+        for handler in logger.handlers:
+            if isinstance(handler, RichHandler):
+                handler.setLevel(level)
+
+_THREAD_NAME_TO_LOG_SUFFIX: dict[str, str] = {}
+
+
+def register_thread_name(name: str) -> None:
+    thread_name = threading.current_thread().name
+    _THREAD_NAME_TO_LOG_SUFFIX[thread_name] = name
+
+
+class _RichHandlerWithEmoji(RichHandler):
+    def __init__(self, emoji: str, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not emoji.endswith(" "):
+            emoji += " "
+        self.emoji = emoji
+
+    def get_level_text(self, record: logging.LogRecord) -> Text:
+        level_name = record.levelname
+        return Text.styled((self.emoji + level_name).ljust(10), f"logging.level.{level_name.lower()}")
+
+
+def get_logger(name: str, *, emoji: str = "🦖") -> logging.Logger:
+    """Get logger. Use this instead of `logging.getLogger` to ensure
+    that the logger is set up with the correct handlers.
+    """
+    thread_name = threading.current_thread().name
+    if thread_name != "MainThread":
+        name = name + "-" + _THREAD_NAME_TO_LOG_SUFFIX.get(thread_name, thread_name)
+    logger = logging.getLogger(name)
+    if name in _SET_UP_LOGGERS:
+        # Already set up by this module
+        return logger
+    handler = _RichHandlerWithEmoji(
+        emoji=emoji,
+        console=_get_console(),
+        show_time=bool(os.environ.get("SWE_AGENT_LOG_TIME", False)),
+        show_path=False,
+    )
+    handler.setLevel(_STREAM_LEVEL)
+    logger.setLevel(_STREAM_LEVEL)
+    logger.addHandler(handler)
+    logger.propagate = False
+    _SET_UP_LOGGERS.add(name)
+    for handler in _ADDITIONAL_HANDLERS:
+        logger.addHandler(handler)
+    return logger

--- a/examples/mini-swe-agent/overlay/mini-swe-agent/pyproject.toml
+++ b/examples/mini-swe-agent/overlay/mini-swe-agent/pyproject.toml
@@ -1,0 +1,290 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+
+[project]
+name = "mini-swe-agent"
+dynamic = ["version"]
+description = "Nano SWE Agent - A simple AI software engineering agent"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {file = "LICENSE.md"}
+keywords = ["nlp", "agents", "code"]
+authors = [
+    {name = "Kilian Lieret", email = "kilian.lieret@posteo.de" },
+    {name = "Carlos E. Jimenez", email = "carlosej@princeton.edu" },
+]
+
+# Classifiers help users find your project by categorizing it.
+classifiers = [
+  # How mature is this project? Common values are
+  #   3 - Alpha, 4 - Beta, 5 - Production/Stable
+  "Development Status :: 3 - Alpha",
+  "Operating System :: OS Independent",
+  # Indicate who your project is intended for
+  "Intended Audience :: Developers",
+  # Pick your license as you wish
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3 :: Only",
+]
+
+dependencies = [
+    "pyyaml",
+    "requests",
+    "jinja2",
+    "pydantic >= 2.0",  # v2 required for safe mutable default arguments
+    "litellm >= 1.75.5, != 1.82.7, != 1.82.8", # Security: Skip compromised 1.82.7/8; requires 1.75.5+ for GPT-5
+    "tenacity",
+    "rich",
+    "python-dotenv",
+    "typer",
+    "platformdirs",
+    "textual",
+    "prompt_toolkit",
+    "datasets",
+    "openai != 1.100.0,!=1.100.1",  # https://github.com/SWE-agent/mini-swe-agent/issues/446
+]
+
+[project.optional-dependencies]
+full = [
+    "mini-swe-agent[dev]",
+    "swe-rex>=1.4.0",
+    "mini-swe-agent[modal]",
+    "mini-swe-agent[contree]",
+]
+
+modal = [
+    "modal",
+    "boto3",
+]
+
+dev = [
+    "pytest",
+    "pytest-cov",
+    "pytest-asyncio",
+    "pytest-xdist",
+    "pre-commit",
+    "ruff",
+    "mkdocs-include-markdown-plugin",
+    "mkdocstrings[python]>=0.18",
+    "mike",
+    "mkdocs-material",
+    "mkdocs-glightbox",
+    "mkdocs-redirects",
+    "portkey-ai",
+    "swe-rex",
+]
+
+contree = [
+    "contree-sdk>=0.2.0",
+]
+
+ags = [
+    "swe-rex[ags]",
+]
+
+[project.urls]
+Documentation = "https://mini-swe-agent.com/latest/"
+Repository = "https://github.com/SWE-agent/mini-swe-agent"
+"Bug Tracker" = "https://github.com/SWE-agent/mini-swe-agent/issues"
+
+[project.scripts]
+mini = "minisweagent.run.mini:app"
+mini-swe-agent = "minisweagent.run.mini:app"
+mini-extra = "minisweagent.run.utilities.mini_extra:main"
+mini-e= "minisweagent.run.utilities.mini_extra:main"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.dynamic]
+version = {attr = "minisweagent.__version__"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["minisweagent*"]
+
+[tool.setuptools.package-data]
+minisweagent = ["config/**/*"]
+
+[tool.ruff]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+    # ---- project specific ----
+    "tests/test_data",
+    # Exclude commands so they don't get the __future__ imports
+    "config/commands",
+]
+
+line-length = 120
+indent-width = 4
+
+target-version = "py310"
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+# I001: Isort, I002: required import
+select = [
+    # Error (E)
+    "E",
+    # Error (PLE)
+    "PLE",
+    # pycodestyle
+    "E713",  # not in
+    "E714",  # is not
+    "E711",  # comparison with None
+    # pyflakes
+    "F821",
+    "F822",
+    "F401",  # unused-import
+    "F841",  # unused var
+    "F541",  # f-string without args
+    "F901",  # raise NotImplemented should be raise NotImplementedError
+    # isort
+    "I001",  # isort
+    "I002",  # required import
+    # pyupgrade and related
+    "UP",    # pyupgrade
+    "C401",  # flake8-comprehensions: unnecessary-generator-set
+    "C402",  # flake8-comprehensions: unnecessary-generator-dict
+    "C403",  # flake8-comprehensions: unnecessary-list-comprehension-set
+    "C404",  # flake8-comprehensions: unnecessary-list-comprehension-dict
+    "C405",  # flake8-comprehensions: unnecessary-literal-set
+    "F632",  # pyflakes: is-literal
+    "W605",  # pycodestyle: invalid-escape-sequence
+    # bugbear
+    "B006",  # mutable default
+    "B007",  # unused loop var
+    "B009",  # getattr with constant
+    # flake8-errmsg
+    "EM",
+    # flake8-return
+    "RET",
+    # RUF
+    "RUF019",  # unneded key in dict check
+    # pytest
+    "PT",
+    # flake8-simplify (SIM)
+    "SIM201",
+    # flake8-use-pathlib
+    "PTH100",
+    "PTH110",
+    "PTH111",
+    "PTH112",
+    "PTH113",
+    "PTH114",
+    "PTH117",
+    "PTH118",
+    "PTH119",
+    "PTH120",
+    "PTH121",
+    "PTH122",
+    "PTH202",
+    "PTH203",
+    "PTH204",
+    "PTH205",
+]
+ignore = [
+    # flake8-return
+    "RET505",  # can't autofix
+    "RET506",  # can't autofix
+    "RET507",  # can't autofix
+    # error (E)
+    "E501",    # line too long
+    "E402",    # import not on top of file
+    "E722",    # bare except
+    "E741",    # ambiguous symbol
+    # pytest
+    "PT011",
+    "PT018",
+    # flake8-errmsg
+    "EM101",   # exception must not use a string literal
+    "EM102",   # exception must not use an f-string literal
+    "EM103",   # exception must not use a .format(...) string directly
+]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+[tool.typos.default.extend-identifiers]
+# *sigh* this just isn't worth the cost of fixing
+ACI = "ACI"
+
+[tool.typos.default.extend-words]
+# Don't correct the surname "Teh"
+aci = "aci"
+ba = "ba"
+
+[tool.pylint.messages_control]
+disable = [
+    "line-too-long",           # C0301 - disable line length checks
+    "missing-docstring",       # C0111 - disable docstring requirements
+    "missing-class-docstring", # C0115 - disable class docstring requirements
+    "missing-function-docstring", # C0116 - disable function docstring requirements
+    "missing-module-docstring", # C0114 - disable module docstring requirements
+    "unspecified-encoding",    # W1514 - disable unspecified encoding warnings
+    "duplicate-code",          # R0801 - disable code duplication checks
+    "too-few-public-methods",  # R0903 - disable too few public methods warnings
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+markers = [
+    "slow: marks tests as slow (deselect with '-k \"not slow\"')",
+]
+
+[dependency-groups]
+dev = [
+    "datasets>=4.5.0",
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+    "pytest-cov>=7.0.0",
+]

--- a/examples/mini-swe-agent/overlay/mini-swe-agent/src/minisweagent/config/benchmarks/swebench_ags.yaml
+++ b/examples/mini-swe-agent/overlay/mini-swe-agent/src/minisweagent/config/benchmarks/swebench_ags.yaml
@@ -1,0 +1,208 @@
+# SWE-bench AGS (Tencent Cloud Agent Sandbox) environment configuration
+
+agent:
+  system_template: |
+    You are a helpful assistant that can interact with a computer shell to solve programming tasks.
+  instance_template: |
+    <pr_description>
+    Consider the following PR description:
+    {{task}}
+    </pr_description>
+
+    <instructions>
+    # Task Instructions
+
+    ## Overview
+
+    You're a software engineer interacting continuously with a computer by submitting commands.
+    You'll be helping implement necessary changes to meet requirements in the PR description.
+    Your task is specifically to make changes to non-test files in the current directory in order to fix the issue described in the PR description in a way that is general and consistent with the codebase.
+    <IMPORTANT>This is an interactive process where you will think and issue AT LEAST ONE command, see the result, then think and issue your next command(s).</important>
+
+    For each response:
+
+    1. Include a THOUGHT section explaining your reasoning and what you're trying to accomplish
+    2. Provide one or more bash tool calls to execute
+
+    ## Important Boundaries
+
+    - MODIFY: Regular source code files in /testbed (this is the working directory for all your subsequent commands)
+    - DO NOT MODIFY: Tests, configuration files (pyproject.toml, setup.cfg, etc.)
+
+    ## Recommended Workflow
+
+    1. Analyze the codebase by finding and reading relevant files
+    2. Create a script to reproduce the issue
+    3. Edit the source code to resolve the issue
+    4. Verify your fix works by running your script again
+    5. Test edge cases to ensure your fix is robust
+
+    ## Command Execution Rules
+
+    You are operating in an environment where
+
+    1. You issue at least one command
+    2. The system executes the command(s) in a subshell
+    3. You see the result(s)
+    4. You write your next command(s)
+
+    Each response should include:
+
+    1. **Reasoning text** where you explain your analysis and plan
+    2. At least one tool call with your command
+
+    **CRITICAL REQUIREMENTS:**
+
+    - Your response SHOULD include reasoning text explaining what you're doing
+    - Your response MUST include AT LEAST ONE bash tool call. You can make MULTIPLE tool calls in a single response when the commands are independent (e.g., searching multiple files, reading different parts of the codebase).
+    - Directory or environment variable changes are not persistent. Every action is executed in a new subshell.
+    - However, you can prefix any action with `MY_ENV_VAR=MY_VALUE cd /path/to/working/dir && ...` or write/load environment variables from files
+
+    Example of a CORRECT response:
+    <example_response>
+    I need to understand the Builder-related code. Let me find relevant files and check the project structure.
+
+    [Makes multiple bash tool calls: {"command": "ls -la"}, {"command": "find src -name '*.java' | grep -i builder"}, {"command": "cat README.md | head -50"}]
+    </example_response>
+
+    ## Environment Details
+
+    - You have a full Linux shell environment
+    - Always use non-interactive flags (-y, -f) for commands
+    - Avoid interactive tools like vi, nano, or any that require user input
+    - You can use bash commands or invoke any tool that is available in the environment
+    - You can also create new tools or scripts to help you with the task
+    - If a tool isn't available, you can also install it
+
+    ## Submission
+
+    When you've completed your work, you MUST submit your changes as a git patch.
+    Follow these steps IN ORDER, with SEPARATE commands:
+
+    Step 1: Create the patch file
+    Run `git diff -- path/to/file1 path/to/file2 > patch.txt` listing only the source files you modified.
+    Do NOT commit your changes.
+
+    <IMPORTANT>
+    The patch must only contain changes to the specific source files you modified to fix the issue.
+    Do not submit file creations or changes to any of the following files:
+
+    - test and reproduction files
+    - helper scripts, tests, or tools that you created
+    - installation, build, packaging, configuration, or setup scripts unless they are directly part of the issue you are fixing (you can assume that the environment is already set up for your client)
+    - binary or compiled files
+    </IMPORTANT>
+
+    Step 2: Verify your patch
+    Inspect patch.txt to confirm it only contains your intended changes and headers show `--- a/` and `+++ b/` paths.
+
+    Step 3: Submit (EXACT command required)
+    You MUST use this EXACT command to submit:
+
+    ```bash
+    echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT && cat patch.txt
+    ```
+
+    If the command fails (nonzero exit status), it will not submit.
+
+    <CRITICAL>
+    - Creating/viewing the patch and submitting it MUST be separate commands (not combined with &&).
+    - If you modify patch.txt after verifying, you SHOULD verify again before submitting.
+    - You CANNOT continue working (reading, editing, testing) in any way on this task after submitting.
+    </CRITICAL>
+    </instructions>
+  step_limit: 250
+  cost_limit: 3.
+
+environment:
+  cwd: "/testbed"
+  timeout: 60
+  interpreter: ["bash", "-c"]
+  env:
+    PAGER: cat
+    MANPAGER: cat
+    LESS: -R
+    PIP_PROGRESS_BAR: "off"
+    TQDM_DISABLE: "1"
+  environment_class: swerex_ags
+  # Tencent AGS SWE sandbox configuration
+  #
+  # Credentials: set via environment variables (recommended):
+  #   export TENCENTCLOUD_SECRET_ID="your-secret-id"
+  #   export TENCENTCLOUD_SECRET_KEY="your-secret-key"
+  #
+  # Or uncomment and set explicitly (not recommended for shared configs):
+  # secret_id: ""
+  # secret_key: ""
+
+  # Required: your SWE sandbox tool ID (created on AGS console)
+  tool_id: ""  # e.g., "sdt-xxxxxxxx"
+
+  # AGS region and endpoint configuration.
+  # Default is ap-chongqing. If your tool is in a different region, update region here.
+  # The data plane domain is auto-derived from region (e.g., ap-chongqing -> ap-chongqing.tencentags.com).
+  # See: https://console.cloud.tencent.com/ags/sandbox/tool
+  region: "ap-chongqing"
+  http_endpoint: "ags.tencentcloudapi.com"
+  skip_ssl_verify: false
+
+  # Timeout configuration
+  startup_timeout: 120.0  # 2 min to allow instance creation
+  runtime_timeout: 60.0  # 1 min HTTP request timeout
+  timeout_duration: "1h"
+
+  # Image: set per-instance to match SWE-bench docker images.
+  # When running via mini-extra swebench, this is set automatically.
+  # image: "swebench/sweb.eval.x86_64.django__django-16379:latest"
+
+model:
+  observation_template: |
+    {% if output.exception_info -%}
+    <exception>{{output.exception_info}}</exception>
+    {% endif -%}
+    <returncode>{{output.returncode}}</returncode>
+    {% if output.output | length < 10000 -%}
+    <output>
+    {{ output.output -}}
+    </output>
+    {%- else -%}
+    <warning>
+    The output of your last command was too long.
+    Please try a different command that produces less output.
+    If you're looking at a file you can try use head, tail or sed to view a smaller number of lines selectively.
+    If you're using grep or find and it produced too much output, you can use a more selective search pattern.
+    If you really need to see something from the full command's output, you can redirect output to a file and then search in that file.
+    </warning>
+    {%- set elided_chars = output.output | length - 10000 -%}
+    <output_head>
+    {{ output.output[:5000] }}
+    </output_head>
+    <elided_chars>
+    {{ elided_chars }} characters elided
+    </elided_chars>
+    <output_tail>
+    {{ output.output[-5000:] }}
+    </output_tail>
+    {%- endif -%}
+  format_error_template: |
+    Tool call error:
+
+    <error>
+    {{error}}
+    </error>
+
+    Here is general guidance on how to submit correct toolcalls:
+
+    Every response needs to use the 'bash' tool at least once to execute commands.
+
+    Call the bash tool with your command as the argument:
+    - Tool: bash
+    - Arguments: {"command": "your_command_here"}
+
+    If you have completed your assignment, please consult the first message about how to
+    submit your solution (you will not be able to continue working on this task after that).
+  model_name: "anthropic/claude-sonnet-4-5-20250929"
+  model_kwargs:
+    drop_params: true
+    temperature: 0.0
+    parallel_tool_calls: true

--- a/examples/mini-swe-agent/overlay/mini-swe-agent/src/minisweagent/environments/__init__.py
+++ b/examples/mini-swe-agent/overlay/mini-swe-agent/src/minisweagent/environments/__init__.py
@@ -1,0 +1,34 @@
+"""Environment implementations for mini-SWE-agent."""
+
+import copy
+import importlib
+
+from minisweagent import Environment
+
+_ENVIRONMENT_MAPPING = {
+    "docker": "minisweagent.environments.docker.DockerEnvironment",
+    "singularity": "minisweagent.environments.singularity.SingularityEnvironment",
+    "local": "minisweagent.environments.local.LocalEnvironment",
+    "swerex_docker": "minisweagent.environments.extra.swerex_docker.SwerexDockerEnvironment",
+    "swerex_modal": "minisweagent.environments.extra.swerex_modal.SwerexModalEnvironment",
+    "swerex_ags": "minisweagent.environments.extra.swerex_ags.SwerexAgsEnvironment",
+    "bubblewrap": "minisweagent.environments.extra.bubblewrap.BubblewrapEnvironment",
+    "contree": "minisweagent.environments.extra.contree.ContreeEnvironment",
+}
+
+
+def get_environment_class(spec: str) -> type[Environment]:
+    full_path = _ENVIRONMENT_MAPPING.get(spec, spec)
+    try:
+        module_name, class_name = full_path.rsplit(".", 1)
+        module = importlib.import_module(module_name)
+        return getattr(module, class_name)
+    except (ValueError, ImportError, AttributeError):
+        msg = f"Unknown environment type: {spec} (resolved to {full_path}, available: {_ENVIRONMENT_MAPPING})"
+        raise ValueError(msg)
+
+
+def get_environment(config: dict, *, default_type: str = "") -> Environment:
+    config = copy.deepcopy(config)
+    environment_class = config.pop("environment_class", default_type)
+    return get_environment_class(environment_class)(**config)

--- a/examples/mini-swe-agent/overlay/mini-swe-agent/src/minisweagent/environments/extra/swerex_ags.py
+++ b/examples/mini-swe-agent/overlay/mini-swe-agent/src/minisweagent/environments/extra/swerex_ags.py
@@ -1,0 +1,263 @@
+"""Tencent AGS (Agent Sandbox) Environment for mini-swe-agent.
+
+This environment uses Tencent Cloud AGS SWE sandbox for isolated code execution.
+SWE sandbox has built-in swerex runtime, providing a ready-to-use environment
+for SWE-bench evaluations.
+
+Usage flow:
+    1. Create a SWE sandbox tool on the AGS console, obtain a tool_id.
+    2. Provide tool_id + credentials to this environment.
+    3. Each instance can use a different SWE-bench image.
+"""
+
+import asyncio
+import logging
+from typing import Any
+
+from pydantic import BaseModel, model_validator
+from swerex.exceptions import CommandTimeoutError, EnvironmentExpiredError, EnvironmentUnavailableError
+from swerex.runtime.abstract import Command as RexCommand
+
+from minisweagent.exceptions import Submitted
+from minisweagent.utils.serialize import recursive_merge
+
+logger = logging.getLogger(__name__)
+
+
+class SwerexAgsEnvironmentConfig(BaseModel):
+    """Configuration for Tencent AGS SWE sandbox environment."""
+
+    tool_id: str
+    """SWE SandboxTool ID (created on AGS console). Required."""
+
+    image: str = ""
+    """SWE image name (e.g., 'swebench/sweb.eval.x86_64.django__django-16379:latest').
+    If empty, uses the default SWE sandbox image."""
+
+    cwd: str = "/"
+    """Working directory in which to execute commands."""
+
+    timeout: int = 60
+    """Timeout for executing commands in the sandbox (seconds)."""
+
+    startup_timeout: float = 120.0
+    """Time to wait for the runtime to start (seconds)."""
+
+    runtime_timeout: float = 60.0
+    """Timeout for runtime HTTP requests (seconds)."""
+
+    # Tencent Cloud credentials (can also be set via environment variables)
+    secret_id: str = ""
+    """Tencent Cloud SecretId (or use TENCENTCLOUD_SECRET_ID env var)."""
+
+    secret_key: str = ""
+    """Tencent Cloud SecretKey (or use TENCENTCLOUD_SECRET_KEY env var)."""
+
+    region: str = "ap-chongqing"
+    """Region for AGS service."""
+
+    domain: str = ""
+    """Domain for sandbox endpoint. Auto-derived from region if empty."""
+
+    http_endpoint: str = "ags.tencentcloudapi.com"
+    """Tencent Cloud HTTP endpoint."""
+
+    skip_ssl_verify: bool = False
+    """Skip SSL certificate verification (for internal/pre-release endpoints)."""
+
+    timeout_duration: str = "1h"
+    """Sandbox instance timeout duration (e.g., '5m', '300s', '1h')."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _fill_credentials_from_env(cls, data: dict) -> dict:
+        """Allow credentials from environment variables as fallback."""
+        import os
+
+        if not isinstance(data, dict):
+            return data
+
+        if not data.get("secret_id"):
+            data["secret_id"] = os.environ.get("TENCENTCLOUD_SECRET_ID", "")
+        if not data.get("secret_key"):
+            data["secret_key"] = os.environ.get("TENCENTCLOUD_SECRET_KEY", "")
+
+        # Auto-derive domain from region if not explicitly set
+        if not data.get("domain"):
+            region = data.get("region", "ap-chongqing")
+            data["domain"] = f"{region}.tencentags.com"
+
+        return data
+
+
+class SwerexAgsEnvironment:
+    """Environment that executes commands in Tencent AGS SWE sandbox.
+
+    This environment uses SWE sandbox which has swerex runtime built-in.
+    Each environment instance creates one sandbox instance with its own runtime.
+
+    Usage:
+        env = SwerexAgsEnvironment(
+            tool_id="sdt-xxxxx",
+            image="swebench/sweb.eval.x86_64.django__django-16379:latest",
+        )
+    """
+
+    def __init__(self, **kwargs: Any):
+        """Initialize and start the AGS SWE sandbox environment.
+
+        Args:
+            **kwargs: Configuration options (see SwerexAgsEnvironmentConfig).
+        """
+        self.config = SwerexAgsEnvironmentConfig(**kwargs)
+        self.deployment = None
+        self._started = False
+        # Create a dedicated event loop for this environment instance
+        # This avoids calling asyncio.run() repeatedly from threads, which can cause
+        # deadlocks due to signal handler conflicts when multiple threads do this
+        self._loop = asyncio.new_event_loop()
+        self._start_deployment()
+
+    def _start_deployment(self) -> None:
+        """Create and start the AGS deployment."""
+        try:
+            from swerex.deployment.ags import TencentAGSDeployment
+        except ImportError as e:
+            raise ImportError(
+                "AGS environment requires SWE-ReX with AGS support. "
+                "Install with: pip install swe-rex[ags] or ensure the SWE-ReX package "
+                "with AGS dependencies is available."
+            ) from e
+
+        deployment_kwargs: dict[str, Any] = {
+            "tool_id": self.config.tool_id,
+            "region": self.config.region,
+            "domain": self.config.domain,
+            "http_endpoint": self.config.http_endpoint,
+            "skip_ssl_verify": self.config.skip_ssl_verify,
+            "timeout": self.config.timeout_duration,
+            "startup_timeout": self.config.startup_timeout,
+            "runtime_timeout": self.config.runtime_timeout,
+        }
+
+        if self.config.image:
+            deployment_kwargs["image"] = self.config.image
+
+        if self.config.secret_id:
+            deployment_kwargs["secret_id"] = self.config.secret_id
+
+        if self.config.secret_key:
+            deployment_kwargs["secret_key"] = self.config.secret_key
+
+        self.deployment = TencentAGSDeployment(**deployment_kwargs)
+        self._loop.run_until_complete(self.deployment.start())
+        self._started = True
+
+    def execute(self, action: dict, cwd: str = "", *, timeout: int | None = None) -> dict[str, Any]:
+        """Execute a command in the AGS sandbox and return the raw output.
+
+        Args:
+            action: Dict with 'command' key containing the bash command to execute.
+            cwd: Working directory for the command (defaults to config.cwd).
+            timeout: Command timeout in seconds (defaults to config.timeout).
+
+        Returns:
+            Dict with 'output', 'returncode', and 'exception_info' keys.
+        """
+        if not self._started or self.deployment is None:
+            return {
+                "output": "",
+                "returncode": -1,
+                "exception_info": "Environment not started",
+            }
+
+        command = action.get("command", "")
+        try:
+            result = self._loop.run_until_complete(
+                self.deployment.runtime.execute(
+                    RexCommand(
+                        command=command,
+                        shell=True,
+                        check=False,
+                        cwd=cwd or self.config.cwd,
+                        timeout=timeout if timeout is not None else self.config.timeout,
+                        merge_output_streams=True,
+                    )
+                )
+            )
+            output = {"output": result.stdout, "returncode": result.exit_code, "exception_info": ""}
+        except CommandTimeoutError as e:
+            output = {
+                "output": str(e) if str(e) else "",
+                "returncode": -1,
+                "exception_info": f"Command timed out: {e}",
+                "extra": {"exception_type": type(e).__name__, "exception": str(e)},
+            }
+        except (EnvironmentExpiredError, EnvironmentUnavailableError):
+            raise
+        except Exception as e:
+            output = {
+                "output": str(e) if str(e) else "",
+                "returncode": -1,
+                "exception_info": f"An error occurred while executing the command: {e}",
+                "extra": {"exception_type": type(e).__name__, "exception": str(e)},
+            }
+        self._check_finished(output)
+        return output
+
+    def _check_finished(self, output: dict) -> None:
+        """Raises Submitted if the output indicates task completion."""
+        lines = output.get("output", "").lstrip().splitlines(keepends=True)
+        if lines and lines[0].strip() == "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT" and output["returncode"] == 0:
+            submission = "".join(lines[1:])
+            raise Submitted(
+                {
+                    "role": "exit",
+                    "content": submission,
+                    "extra": {"exit_status": "Submitted", "submission": submission},
+                }
+            )
+
+    def get_template_vars(self, **kwargs: Any) -> dict[str, Any]:
+        """Get template variables for rendering."""
+        return recursive_merge(self.config.model_dump(), kwargs)
+
+    def serialize(self) -> dict:
+        """Serialize the environment configuration."""
+        return {
+            "info": {
+                "config": {
+                    "environment": self.config.model_dump(mode="json"),
+                    "environment_type": f"{self.__class__.__module__}.{self.__class__.__name__}",
+                }
+            }
+        }
+
+    def stop(self) -> None:
+        """Stop the AGS sandbox instance."""
+        if self.deployment is not None:
+            try:
+                if self._loop is not None and not self._loop.is_running() and not self._loop.is_closed():
+                    self._loop.run_until_complete(
+                        asyncio.wait_for(self.deployment.stop(), timeout=10)
+                    )
+            except Exception:
+                pass
+            finally:
+                self._started = False
+                self.deployment = None
+        # Close the event loop when done
+        if self._loop is not None:
+            try:
+                if not self._loop.is_closed():
+                    self._loop.close()
+            except Exception:
+                pass
+            self._loop = None
+
+    def __del__(self) -> None:
+        """Cleanup when the environment is garbage collected."""
+        try:
+            self.stop()
+        except Exception:
+            pass

--- a/examples/mini-swe-agent/overlay/mini-swe-agent/src/minisweagent/run/benchmarks/swebench.py
+++ b/examples/mini-swe-agent/overlay/mini-swe-agent/src/minisweagent/run/benchmarks/swebench.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+
+"""Run mini-SWE-agent on SWE-bench instances in batch mode."""
+# Read this first: https://mini-swe-agent.com/latest/usage/swebench/  (usage docs)
+
+import concurrent.futures
+import json
+import logging
+import random
+import re
+import threading
+import time
+import traceback
+from pathlib import Path
+
+import typer
+from jinja2 import StrictUndefined, Template
+from rich.console import Console
+from rich.live import Live
+
+from minisweagent import Environment
+from minisweagent.agents.default import DefaultAgent
+from minisweagent.config import builtin_config_dir, get_config_from_spec
+from minisweagent.environments import get_environment
+from minisweagent.models import get_model
+from minisweagent.run.benchmarks.utils.batch_progress import RunBatchProgressManager
+from minisweagent.utils.log import add_file_handler, logger, set_stream_level, setup_logging, shutdown_logging
+from minisweagent.utils.serialize import UNSET, recursive_merge
+from swerex.utils.log import set_console as set_swerex_console, set_stream_level as set_swerex_stream_level
+
+_HELP_TEXT = """Run mini-SWE-agent on SWEBench instances.
+
+[not dim]
+More information about the usage: [bold green]https://mini-swe-agent.com/latest/usage/swebench/[/bold green]
+[/not dim]
+"""
+
+_CONFIG_SPEC_HELP_TEXT = """Path to config files, filenames, or key-value pairs.
+
+[bold red]IMPORTANT:[/bold red] [red]If you set this option, the default config file will not be used.[/red]
+So you need to explicitly set it e.g., with [bold green]-c swebench.yaml <other options>[/bold green]
+
+Multiple configs will be recursively merged.
+
+Examples:
+
+[bold red]-c model.model_kwargs.temperature=0[/bold red] [red]You forgot to add the default config file! See above.[/red]
+
+[bold green]-c swebench.yaml -c model.model_kwargs.temperature=0.5[/bold green]
+
+[bold green]-c swebench.yaml -c agent.max_iterations=50[/bold green]
+"""
+
+DEFAULT_CONFIG_FILE = builtin_config_dir / "benchmarks" / "swebench.yaml"
+
+DATASET_MAPPING = {
+    "full": "princeton-nlp/SWE-Bench",
+    "verified": "princeton-nlp/SWE-Bench_Verified",
+    "lite": "princeton-nlp/SWE-Bench_Lite",
+    "multimodal": "princeton-nlp/SWE-Bench_Multimodal",
+    "multilingual": "swe-bench/SWE-Bench_Multilingual",
+    "smith": "SWE-bench/SWE-smith",
+    "_test": "klieret/swe-bench-dummy-test-dataset",
+    "rebench": "nebius/SWE-rebench",
+}
+
+app = typer.Typer(rich_markup_mode="rich", add_completion=False)
+_OUTPUT_FILE_LOCK = threading.Lock()
+
+
+class ProgressTrackingAgent(DefaultAgent):
+    """Simple wrapper around DefaultAgent that provides progress updates."""
+
+    def __init__(self, *args, progress_manager: RunBatchProgressManager, instance_id: str = "", **kwargs):
+        super().__init__(*args, **kwargs)
+        self.progress_manager: RunBatchProgressManager = progress_manager
+        self.instance_id = instance_id
+
+    def step(self) -> dict:
+        """Override step to provide progress updates."""
+        self.progress_manager.update_instance_status(self.instance_id, f"Step {self.n_calls + 1:3d} (${self.cost:.2f})")
+        return super().step()
+
+
+def get_swebench_docker_image_name(instance: dict) -> str:
+    """Get the image name for a SWEBench instance."""
+    image_name = instance.get("image_name", None) or instance.get("docker_image", None)
+    if image_name is None:
+        # Docker doesn't allow double underscore, so we replace them with a magic token
+        iid = instance["instance_id"]
+        id_docker_compatible = iid.replace("__", "_1776_")
+        image_name = f"swebench/sweb.eval.x86_64.{id_docker_compatible}:latest".lower()
+    return image_name
+
+
+def get_sb_environment(config: dict, instance: dict) -> Environment:
+    env_config = config.setdefault("environment", {})
+    env_config["environment_class"] = env_config.get("environment_class", "docker")
+    image_name = get_swebench_docker_image_name(instance)
+    if env_config["environment_class"] in ["docker", "swerex_modal"]:
+        env_config["image"] = image_name
+    elif env_config["environment_class"] in ["singularity", "contree"]:
+        env_config["image"] = "docker://" + image_name
+    elif env_config["environment_class"] == "swerex_ags":
+        # AGS SWE sandbox uses system images, just pass the image name
+        env_config["image"] = image_name
+
+    env = get_environment(env_config)
+    if startup_command := config.get("run", {}).get("env_startup_command"):
+        startup_command = Template(startup_command, undefined=StrictUndefined).render(**instance)
+        out = env.execute({"command": startup_command})
+        if out["returncode"] != 0:
+            raise RuntimeError(f"Error executing startup command: {out}")
+    return env
+
+
+def update_preds_file(output_path: Path, instance_id: str, model_name: str, result: str):
+    """Update the output JSON file with results from a single instance."""
+    with _OUTPUT_FILE_LOCK:
+        output_data = {}
+        if output_path.exists():
+            output_data = json.loads(output_path.read_text())
+        output_data[instance_id] = {
+            "model_name_or_path": model_name,
+            "instance_id": instance_id,
+            "model_patch": result,
+        }
+        output_path.write_text(json.dumps(output_data, indent=2))
+
+
+def remove_from_preds_file(output_path: Path, instance_id: str):
+    """Remove an instance from the predictions file."""
+    if not output_path.exists():
+        return
+    with _OUTPUT_FILE_LOCK:
+        output_data = json.loads(output_path.read_text())
+        if instance_id in output_data:
+            del output_data[instance_id]
+            output_path.write_text(json.dumps(output_data, indent=2))
+
+
+def process_instance(
+    instance: dict,
+    output_dir: Path,
+    config: dict,
+    progress_manager: RunBatchProgressManager,
+) -> None:
+    """Process a single SWEBench instance.
+
+    Note: This runs in a worker thread. The shared Console is already configured
+    by the main thread before ThreadPoolExecutor is created, so SWE-ReX loggers
+    will use the shared Console for all their output.
+    """
+    instance_id = instance["instance_id"]
+    instance_dir = output_dir / instance_id
+    # avoid inconsistent state if something here fails and there's leftover previous files
+    remove_from_preds_file(output_dir / "preds.json", instance_id)
+    (instance_dir / f"{instance_id}.traj.json").unlink(missing_ok=True)
+    model = get_model(config=config.get("model", {}))
+    task = instance["problem_statement"]
+
+    progress_manager.on_instance_start(instance_id)
+    progress_manager.update_instance_status(instance_id, "Pulling/starting environment")
+
+    agent = None
+    exit_status = None
+    result = None
+    extra_info = {}
+
+    try:
+        env = get_sb_environment(config, instance)
+        agent = ProgressTrackingAgent(
+            model,
+            env,
+            progress_manager=progress_manager,
+            instance_id=instance_id,
+            **config.get("agent", {}),
+        )
+        info = agent.run(task)
+        exit_status = info.get("exit_status")
+        result = info.get("submission")
+    except Exception as e:
+        logger.error(f"Error processing instance {instance_id}: {e}", exc_info=True)
+        exit_status, result = type(e).__name__, ""
+        extra_info = {"traceback": traceback.format_exc(), "exception_str": str(e)}
+    finally:
+        if agent is not None:
+            traj_path = instance_dir / f"{instance_id}.traj.json"
+            agent.save(
+                traj_path,
+                {
+                    "info": {
+                        "exit_status": exit_status,
+                        "submission": result,
+                        **extra_info,
+                    },
+                    "instance_id": instance_id,
+                },
+            )
+            logger.info(f"Saved trajectory to '{traj_path}'")
+        update_preds_file(output_dir / "preds.json", instance_id, model.config.model_name, result)
+        progress_manager.on_instance_end(instance_id, exit_status)
+
+
+def filter_instances(
+    instances: list[dict], *, filter_spec: str, slice_spec: str = "", shuffle: bool = False
+) -> list[dict]:
+    """Filter and slice a list of SWEBench instances."""
+    if shuffle:
+        instances = sorted(instances.copy(), key=lambda x: x["instance_id"])
+        random.seed(42)
+        random.shuffle(instances)
+    before_filter = len(instances)
+    instances = [instance for instance in instances if re.match(filter_spec, instance["instance_id"])]
+    if (after_filter := len(instances)) != before_filter:
+        logger.info(f"Instance filter: {before_filter} -> {after_filter} instances")
+    if slice_spec:
+        values = [int(x) if x else None for x in slice_spec.split(":")]
+        instances = instances[slice(*values)]
+        if (after_slice := len(instances)) != before_filter:
+            logger.info(f"Instance slice: {before_filter} -> {after_slice} instances")
+    return instances
+
+
+# fmt: off
+@app.command(help=_HELP_TEXT)
+def main(
+    subset: str = typer.Option("lite", "--subset", help="SWEBench subset to use or path to a dataset", rich_help_panel="Data selection"),
+    split: str = typer.Option("dev", "--split", help="Dataset split", rich_help_panel="Data selection"),
+    slice_spec: str = typer.Option("", "--slice", help="Slice specification (e.g., '0:5' for first 5 instances)", rich_help_panel="Data selection"),
+    filter_spec: str = typer.Option("", "--filter", help="Filter instance IDs by regex", rich_help_panel="Data selection"),
+    shuffle: bool = typer.Option(False, "--shuffle", help="Shuffle instances", rich_help_panel="Data selection"),
+    output: str = typer.Option("", "-o", "--output", help="Output directory", rich_help_panel="Basic"),
+    workers: int = typer.Option(1, "-w", "--workers", help="Number of worker threads for parallel processing", rich_help_panel="Basic"),
+    model: str | None = typer.Option(None, "-m", "--model", help="Model to use", rich_help_panel="Basic"),
+    model_class: str | None = typer.Option(None, "--model-class", help="Model class to use (e.g., 'anthropic' or 'minisweagent.models.anthropic.AnthropicModel')", rich_help_panel="Advanced"),
+    redo_existing: bool = typer.Option(False, "--redo-existing", help="Redo existing instances", rich_help_panel="Data selection"),
+    config_spec: list[str] = typer.Option([str(DEFAULT_CONFIG_FILE)], "-c", "--config", help=_CONFIG_SPEC_HELP_TEXT, rich_help_panel="Basic"),
+    environment_class: str | None = typer.Option(None, "--environment-class", help="Environment type to use. Recommended are docker or singularity", rich_help_panel="Advanced"),
+) -> None:
+    # fmt: on
+    output_path = Path(output)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Share one Console with Rich Live so screen updates remain consistent.
+    # Keep the stream log volume low during batch execution; detailed logs still
+    # go to the file handler.
+    shared_console = Console(stderr=True, force_terminal=True)
+    setup_logging(shared_console)
+    set_stream_level(logging.WARNING)
+    set_swerex_console(shared_console)
+    # Set SWE-ReX stream level to CRITICAL+1 to suppress all RichHandler output
+    # in worker threads. This avoids the ABBA deadlock between Handler._lock and
+    # Console._lock when Rich Live is refreshing. SWE-ReX logs still reach the
+    # file handler, so no information is lost.
+    set_swerex_stream_level(logging.CRITICAL + 1)
+
+    # Suppress LiteLLM's direct print() output to avoid interfering with Rich Live
+    import litellm
+    litellm.suppress_debug_info = True
+
+    logger.info(f"Results will be saved to {output_path}")
+    add_file_handler(output_path / "minisweagent.log")
+
+    from datasets import load_dataset
+
+    dataset_path = DATASET_MAPPING.get(subset, subset)
+    logger.info(f"Loading dataset {dataset_path}, split {split}...")
+    instances = list(load_dataset(dataset_path, split=split))
+
+    instances = filter_instances(instances, filter_spec=filter_spec, slice_spec=slice_spec, shuffle=shuffle)
+    if not redo_existing and (output_path / "preds.json").exists():
+        existing_instances = list(json.loads((output_path / "preds.json").read_text()).keys())
+        logger.info(f"Skipping {len(existing_instances)} existing instances")
+        instances = [instance for instance in instances if instance["instance_id"] not in existing_instances]
+    logger.info(f"Running on {len(instances)} instances...")
+
+    logger.info(f"Building agent config from specs: {config_spec}")
+    configs = [get_config_from_spec(spec) for spec in config_spec]
+    configs.append({
+        "environment": {"environment_class": environment_class or UNSET},
+        "model": {"model_name": model or UNSET, "model_class": model_class or UNSET},
+    })
+    config = recursive_merge(*configs)
+
+    progress_manager = RunBatchProgressManager(len(instances), output_path / f"exit_statuses_{time.time()}.yaml")
+
+    def process_futures(futures: dict[concurrent.futures.Future, str]):
+        for future in concurrent.futures.as_completed(futures):
+            try:
+                future.result()
+            except concurrent.futures.CancelledError:
+                pass
+            except Exception as e:
+                instance_id = futures[future]
+                logger.error(f"Error in future for instance {instance_id}: {e}", exc_info=True)
+                progress_manager.on_uncaught_exception(instance_id, e)
+
+    with Live(progress_manager.render_group, console=shared_console, refresh_per_second=4, redirect_stdout=False, redirect_stderr=False):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = {
+                executor.submit(process_instance, instance, output_path, config, progress_manager): instance[
+                    "instance_id"
+                ]
+                for instance in instances
+            }
+            try:
+                process_futures(futures)
+            except KeyboardInterrupt:
+                logger.info("Cancelling all pending jobs. Press ^C again to exit immediately.")
+                for future in futures:
+                    if not future.running() and not future.done():
+                        future.cancel()
+                # Wait for running futures with a timeout to avoid hanging
+                try:
+                    done, not_done = concurrent.futures.wait(
+                        futures, timeout=10, return_when=concurrent.futures.ALL_COMPLETED
+                    )
+                    if not_done:
+                        logger.warning(f"{len(not_done)} tasks did not complete within timeout, forcing exit...")
+                except KeyboardInterrupt:
+                    logger.info("Force exiting...")
+                    # Let the context managers clean up
+    shutdown_logging()
+
+
+if __name__ == "__main__":
+    app()

--- a/examples/mini-swe-agent/overlay/mini-swe-agent/src/minisweagent/run/benchmarks/utils/batch_progress.py
+++ b/examples/mini-swe-agent/overlay/mini-swe-agent/src/minisweagent/run/benchmarks/utils/batch_progress.py
@@ -1,0 +1,184 @@
+"""This module contains an auxiliary class for rendering progress of a batch run.
+It's identical to the one used in swe-agent.
+"""
+
+import collections
+import time
+from datetime import timedelta
+from pathlib import Path
+from threading import RLock
+
+import yaml
+from rich.console import Group
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    TaskID,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
+from rich.table import Table
+
+from minisweagent.utils.log import logger
+
+import minisweagent.models
+
+
+def _shorten_str(s: str, max_len: int, shorten_left=False) -> str:
+    if not shorten_left:
+        s = s[: max_len - 3] + "..." if len(s) > max_len else s
+    else:
+        s = "..." + s[-max_len + 3 :] if len(s) > max_len else s
+    return f"{s:<{max_len}}"
+
+
+class RunBatchProgressManager:
+    def __init__(
+        self,
+        num_instances: int,
+        yaml_report_path: Path | None = None,
+    ):
+        """This class manages a progress bar/UI for run-batch
+
+        Args:
+            num_instances: Number of task instances
+            yaml_report_path: Path to save a yaml report of the instances and their exit statuses
+        """
+
+        self._spinner_tasks: dict[str, TaskID] = {}
+        """We need to map instance ID to the task ID that is used by the rich progress bar."""
+
+        self._lock = RLock()
+        self._start_time = time.time()
+        self._total_instances = num_instances
+
+        self._instances_by_exit_status = collections.defaultdict(list)
+        self._main_progress_bar = Progress(
+            SpinnerColumn(spinner_name="dots2"),
+            TextColumn("[progress.description]{task.description} (${task.fields[total_cost]})"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TaskProgressColumn(),
+            TimeElapsedColumn(),
+            TextColumn("[cyan]{task.fields[eta]}[/cyan]"),
+            # Wait 5 min before estimating speed
+            speed_estimate_period=60 * 5,
+        )
+        self._task_progress_bar = Progress(
+            SpinnerColumn(spinner_name="dots2"),
+            TextColumn("{task.fields[instance_id]}"),
+            TextColumn("{task.fields[status]}"),
+            TimeElapsedColumn(),
+        )
+        """Task progress bar for individual instances. There's only one progress bar
+        with one task for each instance.
+        """
+
+        self._main_task_id = self._main_progress_bar.add_task(
+            "[cyan]Overall Progress", total=num_instances, total_cost="0.00", eta=""
+        )
+
+        self.render_group = Group(self._main_progress_bar, Table(), self._task_progress_bar)
+        self._yaml_report_path = yaml_report_path
+
+    @property
+    def n_completed(self) -> int:
+        return sum(len(instances) for instances in self._instances_by_exit_status.values())
+
+    def _get_eta_text(self) -> str:
+        """Calculate estimated time remaining based on current progress."""
+        try:
+            estimated_remaining = (
+                (time.time() - self._start_time) / self.n_completed * (self._total_instances - self.n_completed)
+            )
+            return f"eta: {timedelta(seconds=int(estimated_remaining))}"
+        except ZeroDivisionError:
+            return ""
+
+    def update_exit_status_table(self):
+        # We cannot update the existing table, so we need to create a new one and
+        # assign it back to the render group.
+        t = Table()
+        t.add_column("Exit Status")
+        t.add_column("Count", justify="right", style="bold cyan")
+        t.add_column("Most recent instances")
+        t.show_header = False
+        with self._lock:
+            t.show_header = True
+            # Sort by number of instances in descending order
+            sorted_items = sorted(self._instances_by_exit_status.items(), key=lambda x: len(x[1]), reverse=True)
+            for status, instances in sorted_items:
+                instances_str = _shorten_str(", ".join(reversed(instances)), 55)
+                t.add_row(status, str(len(instances)), instances_str)
+            assert self.render_group is not None
+            self.render_group.renderables[1] = t
+
+    def _update_total_costs(self) -> None:
+        with self._lock:
+            self._main_progress_bar.update(
+                self._main_task_id,
+                total_cost=f"{minisweagent.models.GLOBAL_MODEL_STATS.cost:.2f}",
+                eta=self._get_eta_text(),
+            )
+
+    def update_instance_status(self, instance_id: str, message: str):
+        assert self._task_progress_bar is not None
+        assert self._main_progress_bar is not None
+        with self._lock:
+            self._task_progress_bar.update(
+                self._spinner_tasks[instance_id],
+                status=_shorten_str(message, 30),
+                instance_id=_shorten_str(instance_id, 35, shorten_left=True),
+            )
+        self._update_total_costs()
+
+    def on_instance_start(self, instance_id: str):
+        with self._lock:
+            self._spinner_tasks[instance_id] = self._task_progress_bar.add_task(
+                description=f"Task {instance_id}",
+                status="Task initialized",
+                total=None,
+                instance_id=instance_id,
+            )
+
+    def on_instance_end(self, instance_id: str, exit_status: str | None) -> None:
+        with self._lock:
+            self._instances_by_exit_status[exit_status].append(instance_id)
+            try:
+                self._task_progress_bar.remove_task(self._spinner_tasks[instance_id])
+            except KeyError:
+                pass
+            self._main_progress_bar.update(self._main_task_id, advance=1, eta=self._get_eta_text())
+        self.update_exit_status_table()
+        self._update_total_costs()
+        if self._yaml_report_path is not None:
+            with self._lock:
+                self._save_overview_data_yaml(self._yaml_report_path)
+
+    def on_uncaught_exception(self, instance_id: str, exception: Exception) -> None:
+        self.on_instance_end(instance_id, f"Uncaught {type(exception).__name__}")
+
+    def print_report(self) -> None:
+        """Print complete list of instances and their exit statuses."""
+        for status, instances in self._instances_by_exit_status.items():
+            # Use logger instead of print() to avoid deadlock with Live's stdout redirection
+            logger.info(f"{status}: {len(instances)}")
+            for instance in instances:
+                logger.info(f"  {instance}")
+
+    def _get_overview_data(self) -> dict:
+        """Get data like exit statuses, total costs, etc."""
+        return {
+            # convert defaultdict to dict because of serialization
+            "instances_by_exit_status": dict(self._instances_by_exit_status),
+        }
+
+    def _save_overview_data_yaml(self, path: Path) -> None:
+        """Save a yaml report of the instances and their exit statuses.
+
+        Caller must hold ``self._lock``.
+        """
+        path.write_text(yaml.dump(self._get_overview_data(), indent=4))

--- a/examples/mini-swe-agent/overlay/mini-swe-agent/src/minisweagent/utils/log.py
+++ b/examples/mini-swe-agent/overlay/mini-swe-agent/src/minisweagent/utils/log.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import logging
+import logging.handlers
+import queue
+from pathlib import Path
+
+from rich.console import Console
+from rich.logging import RichHandler
+
+# Console instance shared across all minisweagent loggers.
+_logging_console: Console | None = None
+
+# The underlying RichHandler (consumed by the QueueListener, not attached to
+# the root logger directly).
+_actual_rich_handler: RichHandler | None = None
+
+# The handler attached to the root logger.  In queue mode this is a
+# QueueHandler; in simple mode it is the RichHandler itself.
+_root_handler: logging.Handler | None = None
+
+# Queue-based logging infrastructure for thread-safe Rich output.
+_log_queue: queue.Queue | None = None
+_queue_listener: logging.handlers.QueueListener | None = None
+
+
+def _ensure_setup() -> Console:
+    """Lazily set up the root logger with a default Console if not yet done."""
+    if _logging_console is not None:
+        return _logging_console
+
+    return setup_logging()
+
+
+def setup_logging(console: Console | None = None) -> Console:
+    """Initialise (or re-initialise) the root ``minisweagent`` logger.
+
+    Args:
+        console: Rich Console to use for log output.  If *None* a new
+                 stderr Console is created (suitable for non-batch / interactive
+                 use).
+
+    Returns:
+        The Console instance attached to the logger.
+
+    When called with a *console* argument after the logger has already been
+    set up (e.g. at import time), the existing handler is replaced so that all
+    subsequent log output goes through the new Console.  This allows batch
+    runners to call ``setup_logging(shared_console)`` **after** imports and
+    have the shared Console take effect.
+
+    In batch mode (when a shared Console is provided), a ``QueueHandler`` /
+    ``QueueListener`` pair is used so that only a single listener thread ever
+    calls ``Console.print()``, avoiding lock contention with Rich ``Live``.
+    """
+    global _logging_console, _actual_rich_handler, _root_handler
+    global _log_queue, _queue_listener
+
+    if console is None:
+        if _logging_console is not None:
+            # Already initialised with defaults, nothing to do.
+            return _logging_console
+        console = Console(stderr=True, force_terminal=True)
+
+    root = logging.getLogger("minisweagent")
+    root.setLevel(logging.DEBUG)
+
+    # Tear down previous setup.
+    shutdown_logging()
+    if _root_handler is not None:
+        root.removeHandler(_root_handler)
+
+    # Build the RichHandler (the real sink).
+    rich_handler = RichHandler(
+        console=console,
+        show_path=False,
+        show_time=False,
+        show_level=False,
+        markup=True,
+    )
+    formatter = logging.Formatter("%(name)s: %(levelname)s: %(message)s")
+    rich_handler.setFormatter(formatter)
+
+    # Route log records through a queue so only the listener thread touches the
+    # Console — this eliminates contention between worker threads and the Rich
+    # Live refresh thread.
+    _log_queue = queue.Queue(-1)
+    queue_handler = logging.handlers.QueueHandler(_log_queue)
+    root.addHandler(queue_handler)
+
+    _queue_listener = logging.handlers.QueueListener(
+        _log_queue, rich_handler, respect_handler_level=True,
+    )
+    _queue_listener.start()
+
+    _logging_console = console
+    _actual_rich_handler = rich_handler
+    _root_handler = queue_handler
+
+    return console
+
+
+def shutdown_logging() -> None:
+    """Stop the QueueListener (if running).
+
+    Call this after the Rich ``Live`` context exits to flush remaining log
+    records and release the listener thread.
+    """
+    global _queue_listener
+    if _queue_listener is not None:
+        _queue_listener.stop()
+        _queue_listener = None
+
+
+def get_logging_console() -> Console | None:
+    """Return the Console currently used for logging (or *None*)."""
+    return _logging_console
+
+
+def set_stream_level(level: int) -> None:
+    """Adjust the Rich stream handler level without affecting file handlers."""
+    if _actual_rich_handler is not None:
+        _actual_rich_handler.setLevel(level)
+
+
+def add_file_handler(path: Path | str, level: int = logging.DEBUG, *, print_path: bool = True) -> None:
+    root = logging.getLogger("minisweagent")
+    handler = logging.FileHandler(path)
+    handler.setLevel(level)
+    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    root.addHandler(handler)
+    if print_path:
+        root.info(f"Logging to '{path}'")
+
+
+# Auto-setup with default Console so that ``from minisweagent.utils.log import logger``
+# works without an explicit ``setup_logging()`` call (e.g. interactive mode).
+# Batch runners can later call ``setup_logging(shared_console)`` to switch to a
+# shared Console before any worker threads start.
+_ensure_setup()
+logger = logging.getLogger("minisweagent")
+
+
+__all__ = ["logger", "setup_logging", "shutdown_logging", "get_logging_console", "set_stream_level", "add_file_handler"]


### PR DESCRIPTION
This pull request adds a new advanced example, `mini-swe-agent`, for running SWE-bench Verified evaluations using the AGS SWE sandbox, and includes comprehensive documentation and setup scripts in both English and Chinese. The changes integrate the new example into the project’s documentation, provide environment and configuration templates, and supply a Makefile for streamlined setup and execution.

**New Example Integration and Documentation**

* Added the `mini-swe-agent` example to all relevant example listings in `README.md`, `README_zh.md`, and `examples/README.md`, describing it as an advanced Python example for SWE-bench evaluation using AGS SWE sandbox and SWE-ReX runtime. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R78) [[2]](diffhunk://#diff-bc53aca037f8d406f619f15cf2c5c905a7a61f81f89cab98dd52f7ff65725f6eR75) [[3]](diffhunk://#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9R17) [[4]](diffhunk://#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9R47)
* Added detailed English and Chinese documentation (`README.md`, `README_zh.md`) in `examples/mini-swe-agent`, covering prerequisites, setup steps, configuration, usage, troubleshooting, results, and code structure. [[1]](diffhunk://#diff-b18c3a677df99e3e3b8fae3d40cf7a0830261765d9f91ccc447d1f55f5f99a5eR1-R211) [[2]](diffhunk://#diff-cc2d36f10802b71fc89283d1d91bb59696764a1d49517fbae680701a79ccf0a4R1-R211)

**Setup and Execution Support**

* Added a `Makefile` to `examples/mini-swe-agent` with targets for setup (`make setup`), single-instance run (`make run`), and full benchmark run (`make run-full`), including dependency checks and instructions for concurrent execution.
* Provided a `.env.example` file for specifying Tencent Cloud credentials and optional HuggingFace dataset settings, and updated `.gitignore` to exclude sensitive and generated files. [[1]](diffhunk://#diff-4a88faf034102023d51b73f5ef6d41094434f0e01abc92918132acd42dfcedd7R1-R8) [[2]](diffhunk://#diff-5560f2f8a521eba924741bde553cea1603bd16533dcf732abda9e4c6e8509904R1-R5)