### PR TITLE
feat(examples): add hermes-cookbook for running Hermes Agent on AGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ You can also enter an example directory directly and run its local `make setup` 
 | `browser-agent` | Python + browser sandbox + LLM | Browser automation agent |
 | `custom-image-go-sdk` | Go | Custom-image / custom-tool startup |
 | `data-analysis` | Python + code sandbox | Multi-context data workflow |
+| `hermes-cookbook` | Node.js + custom image + CFS | Run Hermes Agent in AGS with official image |
 | `html-processing` | Python + browser/code sandboxes | Dual-sandbox HTML pipeline |
 | `hybrid-cookbook` | Go | Minimal control-plane + data-plane flow |
 | `mini-rl` | Python + code sandbox | Minimal RL tool-calling example |

--- a/README_zh.md
+++ b/README_zh.md
@@ -69,6 +69,7 @@ make example-run EXAMPLE=mini-rl
 | `browser-agent` | Python + 浏览器沙箱 + LLM | 浏览器自动化 Agent |
 | `custom-image-go-sdk` | Go | 自定义镜像 / 自定义工具启动 |
 | `data-analysis` | Python + 代码沙箱 | 多 Context 数据分析 |
+| `hermes-cookbook` | Node.js + 自定义镜像 + CFS | 基于官方镜像在 AGS 中运行 Hermes Agent |
 | `html-processing` | Python + Browser/Code 双沙箱 | HTML 协作处理 |
 | `hybrid-cookbook` | Go | 最小控制面 + 数据面流程 |
 | `mini-rl` | Python + 代码沙箱 | 最小 RL Tool Calling 示例 |

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ This directory contains runnable AGS examples. Each example keeps its own README
 
 - `browser-agent` — browser automation agent with an OpenAI-compatible LLM backend
 - `data-analysis` — multi-context data workflow with multiple generated artifacts
+- `hermes-cookbook` — run Hermes Agent in AGS with official image, local management UI and CFS persistence
 - `mini-swe-agent` — SWE-bench evaluation with AGS SWE sandbox and SWE-ReX runtime
 - `mobile-use` — Android / Appium automation in AGS
 - `openclaw-cookbook` — run OpenClaw in AGS with official image, local management UI and COS persistence
@@ -41,6 +42,7 @@ Some heavier or externally overlaid examples are exceptions, but they should sti
 | `browser-agent` | advanced | Python + browser sandbox + LLM | `make run` | Requires OpenAI-compatible LLM backend env vars |
 | `custom-image-go-sdk` | advanced | Go | `make run` | Requires custom tool/image setup in AGS account |
 | `data-analysis` | advanced | Python + code sandbox | `make run` | Generates multiple output files |
+| `hermes-cookbook` | advanced | Node.js + custom image + CFS | `make run` | Run Hermes Agent in AGS with official image; includes local management UI |
 | `html-processing` | starter | Python + browser/code sandboxes | `make run` | Good visual intro to dual-sandbox flow |
 | `hybrid-cookbook` | starter | Go | `make run` | Minimal Go integration path |
 | `mini-rl` | starter | Python + code sandbox | `make run` | Smallest Python example |

--- a/examples/README_zh.md
+++ b/examples/README_zh.md
@@ -14,6 +14,7 @@
 
 - `browser-agent` —— 基于 OpenAI-compatible LLM 的浏览器自动化 Agent
 - `data-analysis` —— 多 Context 数据工作流，生成多个产物
+- `hermes-cookbook` —— 基于官方镜像在 AGS 中运行 Hermes Agent，含本地管理界面与 CFS 持久化
 - `mini-swe-agent` —— 基于 AGS SWE Sandbox 和 SWE-ReX runtime 运行 SWE-bench 评测
 - `mobile-use` —— 在 AGS 中运行 Android / Appium 自动化
 - `openclaw-cookbook` —— 基于官方镜像在 AGS 中运行 OpenClaw，含本地管理界面与 COS 持久化
@@ -41,6 +42,7 @@
 | `browser-agent` | 进阶 | Python + 浏览器沙箱 + LLM | `make run` | 需要 OpenAI-compatible LLM backend 环境变量 |
 | `custom-image-go-sdk` | 进阶 | Go | `make run` | 依赖 AGS 账号中的自定义工具 / 镜像配置 |
 | `data-analysis` | 进阶 | Python + 代码沙箱 | `make run` | 会生成多种图表与报告文件 |
+| `hermes-cookbook` | 进阶 | Node.js + 自定义镜像 + CFS | `make run` | 基于官方镜像在 AGS 中运行 Hermes Agent；含本地管理界面 |
 | `html-processing` | 入门 | Python + 浏览器/代码双沙箱 | `make run` | 适合作为双沙箱协作的直观起点 |
 | `hybrid-cookbook` | 入门 | Go | `make run` | 最小 Go 集成路径 |
 | `mini-rl` | 入门 | Python + 代码沙箱 | `make run` | 最小 Python 示例 |

--- a/examples/hermes-cookbook/.env.example
+++ b/examples/hermes-cookbook/.env.example
@@ -1,0 +1,37 @@
+# ============================================================================
+# Hermes Cookbook Configuration
+# ============================================================================
+# Copy this file to localproxy/.env and fill in your values:
+#   cp .env.example localproxy/.env
+#
+# This file is used by both Makefile (build/push) and localproxy (create-tool/run).
+# ============================================================================
+
+# --- Tencent Cloud API credentials (required) ---
+TENCENTCLOUD_SECRET_ID=your_secret_id_here
+TENCENTCLOUD_SECRET_KEY=your_secret_key_here
+TENCENTCLOUD_REGION=ap-guangzhou
+
+# --- Image registry (required for build/push) ---
+# Full registry path, e.g. ccr.ccs.tencentyun.com/your-namespace
+DOCKER_REGISTRY=ccr.ccs.tencentyun.com/your-namespace
+
+# --- AGS sandbox tool (required for create-tool/run) ---
+TOOL_NAME=my-hermes-agent
+
+# --- Storage mount (required for create-tool) ---
+# CFS file system ID (find in https://console.cloud.tencent.com/cfs)
+CFS_FILE_SYSTEM_ID=cfs-xxxxxxxx
+
+# --- IAM role (required for create-tool) ---
+# CAM role ARN for AGS to pull image (https://console.cloud.tencent.com/cam/role)
+ROLE_ARN=qcs::cam::uin/100000000000:roleName/your-ags-role
+
+# --- Optional overrides (uncomment to customize) ---
+# APP_NAME=sandbox-hermes
+# VERSION=latest
+# CONTAINER_ENGINE=podman
+# MOUNT_NAME=cfs
+# CFS_PATH=/
+# IMAGE_ADDRESS=ccr.ccs.tencentyun.com/your-namespace/sandbox-hermes:latest
+# IMAGE_REGISTRY_TYPE=personal

--- a/examples/hermes-cookbook/.gitignore
+++ b/examples/hermes-cookbook/.gitignore
@@ -1,0 +1,11 @@
+# OS
+.DS_Store
+
+# Docker build artifact
+bin/envd
+
+# Node / localproxy
+localproxy/node_modules/
+localproxy/dist/
+localproxy/.env
+localproxy/package-lock.json

--- a/examples/hermes-cookbook/Dockerfile
+++ b/examples/hermes-cookbook/Dockerfile
@@ -1,0 +1,49 @@
+FROM nousresearch/hermes-agent:v2026.4.23
+
+USER root
+
+COPY --from=ccr.ccs.tencentyun.com/ags-image/envd:latest --chmod=755 /usr/bin/envd /usr/bin/envd
+
+RUN cat > /entrypoint.sh <<'EOF'
+#!/bin/bash
+set -e
+
+mkdir -p /logs
+
+# 1. Start envd
+/usr/bin/envd >/logs/envd.log 2>&1 &
+
+# 2. Initialize Hermes
+HERMES_HOME="${HERMES_HOME:-/opt/data}"
+INSTALL_DIR="/opt/hermes"
+
+source "${INSTALL_DIR}/.venv/bin/activate"
+
+mkdir -p "$HERMES_HOME"/{cron,sessions,logs,hooks,memories,skills,skins,plans,workspace,home}
+
+if [ ! -f "$HERMES_HOME/.env" ]; then
+    cp "$INSTALL_DIR/.env.example" "$HERMES_HOME/.env"
+fi
+
+if [ ! -f "$HERMES_HOME/config.yaml" ]; then
+    cp "$INSTALL_DIR/cli-config.yaml.example" "$HERMES_HOME/config.yaml"
+fi
+
+if [ ! -f "$HERMES_HOME/SOUL.md" ]; then
+    cp "$INSTALL_DIR/docker/SOUL.md" "$HERMES_HOME/SOUL.md"
+fi
+
+if [ -d "$INSTALL_DIR/skills" ]; then
+    python3 "$INSTALL_DIR/tools/skills_sync.py" >/logs/skills_sync.log 2>&1
+fi
+
+# 3. Start dashboard in background
+hermes dashboard --host 0.0.0.0 --insecure --no-open >/logs/dashboard.log 2>&1 &
+
+# 4. Start gateway as main process
+exec hermes gateway run --accept-hooks >/logs/gateway.log 2>&1
+EOF
+
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/examples/hermes-cookbook/Makefile
+++ b/examples/hermes-cookbook/Makefile
@@ -1,0 +1,49 @@
+# Load variables from localproxy/.env if it exists
+ifneq (,$(wildcard localproxy/.env))
+  include localproxy/.env
+  export
+endif
+
+APP_NAME ?= sandbox-hermes
+VERSION ?= latest
+IMAGE_LATEST = $(DOCKER_REGISTRY)/$(APP_NAME):$(VERSION)
+
+CONTAINER_ENGINE ?= podman
+
+.PHONY: setup build push run run-local stop create_sandbox_tool
+
+setup:
+	@test -f localproxy/.env || (cp .env.example localproxy/.env && echo "Created localproxy/.env from .env.example -- please edit it with your credentials")
+	cd localproxy && pnpm install
+
+build:
+	@test -n "$(DOCKER_REGISTRY)" || { echo "Error: DOCKER_REGISTRY is not set. Please set it in localproxy/.env"; exit 1; }
+	$(CONTAINER_ENGINE) build --platform linux/amd64 -t $(IMAGE_LATEST) .
+
+push: build
+	@echo "Getting image hash from $(IMAGE_LATEST)..."
+	@IMAGE_HASH=$$($(CONTAINER_ENGINE) inspect --format='{{.Id}}' $(IMAGE_LATEST) | cut -d: -f2 | cut -c1-12); \
+	IMAGE_HASH_TAG=$(DOCKER_REGISTRY)/$(APP_NAME):$$IMAGE_HASH; \
+	echo "Tagging and pushing with hash: $$IMAGE_HASH"; \
+	$(CONTAINER_ENGINE) tag $(IMAGE_LATEST) $$IMAGE_HASH_TAG; \
+	$(CONTAINER_ENGINE) push $(IMAGE_LATEST); \
+	$(CONTAINER_ENGINE) push $$IMAGE_HASH_TAG; \
+	echo "Pushed: $(IMAGE_LATEST)"; \
+	echo "Pushed: $$IMAGE_HASH_TAG"
+
+run:
+	cd localproxy && pnpm start
+
+# NOTE: run-local does NOT include the auto-restart loop used in AGS production.
+# If Hermes crashes, the container exits. This is intentional for local debugging
+# so crashes are immediately visible. See README for the AGS startup parameters.
+run-local:
+	$(CONTAINER_ENGINE) run --rm -it --platform linux/amd64 -p 9119:9119 -p 8642:8642 -p 49983:49983 \
+		-e GATEWAY_ALLOW_ALL_USERS=true \
+		--name $(APP_NAME) $(IMAGE_LATEST)
+
+stop:
+	$(CONTAINER_ENGINE) stop $(APP_NAME)
+
+create_sandbox_tool:
+	cd localproxy && pnpm run create-tool

--- a/examples/hermes-cookbook/README.md
+++ b/examples/hermes-cookbook/README.md
@@ -1,0 +1,342 @@
+# Hermes Agent Sandbox Guide
+
+Run [Hermes Agent](https://github.com/NousResearch/hermes-agent) on Tencent Cloud AGS using the official `nousresearch/hermes-agent` image. Hermes uses default configuration on first boot — no config file upload needed.
+
+---
+
+## Table of Contents
+
+1. [Architecture](#architecture)
+2. [Prerequisites](#prerequisites)
+3. [Build and Push Image](#build-and-push-image)
+4. [Create Sandbox Tool](#create-sandbox-tool)
+5. [Launch Sandbox and Access Dashboard](#launch-sandbox-and-access-dashboard)
+6. [Persistent Storage](#persistent-storage)
+7. [Logs and Debugging](#logs-and-debugging)
+8. [FAQ](#faq)
+
+---
+
+## Architecture
+
+```
+Browser
+  |
+  +- http://localhost:3001/_admin     <-- localproxy management UI (create/connect/stop sandbox)
+  |
+  +- http://localhost:3001/           <-- reverse proxy to Hermes Dashboard (when sandbox is running)
+       |  Automatically injects X-Access-Token header
+       v
+  AGS Auth Gateway (<region>.tencentags.com)
+       |  Validates X-Access-Token
+       v
+  Hermes Dashboard:9119 (--host 0.0.0.0, --insecure)
+```
+
+**Container processes:**
+
+| Process | Port | Purpose |
+|---------|------|---------|
+| `envd` | 49983 | AGS sandbox management daemon (health probe, command execution) |
+| `hermes dashboard` | 9119 | Hermes Dashboard, `--host 0.0.0.0` listens on all network interfaces |
+| `hermes gateway` | 8642 | Hermes Gateway (agent execution, hooks) |
+
+---
+
+## Prerequisites
+
+### Tool Dependencies
+
+| Tool | Purpose | Installation |
+|------|---------|-------------|
+| `podman` or `docker` | Build/push images | [podman.io](https://podman.io) / [docker.com](https://docker.com) |
+| `Node.js >= 20` | Run local proxy | [nodejs.org](https://nodejs.org) |
+| `pnpm` | Package manager | `npm install -g pnpm` |
+
+### Credentials
+
+localproxy uses the Tencent Cloud AGS SDK to manage sandboxes. The following credentials are required:
+
+| Credential | Description | How to Obtain |
+|------------|-------------|---------------|
+| `TENCENTCLOUD_SECRET_ID` | Tencent Cloud API Key ID | [API Key Management](https://console.cloud.tencent.com/cam/capi) |
+| `TENCENTCLOUD_SECRET_KEY` | Tencent Cloud API Key Secret | Same as above |
+
+Log in to the image registry:
+
+```bash
+podman login ccr.ccs.tencentyun.com
+```
+
+---
+
+## Build and Push Image
+
+### Directory Structure
+
+```
+hermes-cookbook/
++-- .env.example        # Environment variable template (copied to localproxy/.env on make setup)
++-- .gitignore
++-- Dockerfile          # FROM official image, COPY --from AGS envd image, custom entrypoint
++-- Makefile
++-- README.md           # This file (English)
++-- README_zh.md        # Chinese version
++-- localproxy/         # Local management tool (create/connect/stop sandbox + reverse proxy)
+    +-- .env.example    # Environment variable template
+    +-- .gitignore
+    +-- README.md       # LocalProxy documentation (English)
+    +-- README_zh.md    # LocalProxy documentation (Chinese)
+    +-- package.json
+    +-- pnpm-lock.yaml
+    +-- create-tool.ts  # Script to create sandbox tool via AGS SDK
+    +-- server.ts       # Main service: Express + state machine + SSE + embedded Web UI
+```
+
+### Build and Push
+
+> **Important**: The AGS runtime is `linux/amd64`. You must build an amd64 image. The Makefile defaults to `--platform linux/amd64`, which cross-compiles automatically on Apple Silicon Macs.
+
+> The Makefile defaults to `podman`. Docker users can override via `make push CONTAINER_ENGINE=docker`.
+
+```bash
+cd hermes-cookbook
+
+make setup   # Creates localproxy/.env from template
+
+# Set DOCKER_REGISTRY in localproxy/.env
+# DOCKER_REGISTRY=ccr.ccs.tencentyun.com/your-namespace
+
+# Build and push (pushes both latest and hash tags)
+make push
+# Example output:
+# Pushed: ccr.ccs.tencentyun.com/your-namespace/sandbox-hermes:latest
+# Pushed: ccr.ccs.tencentyun.com/your-namespace/sandbox-hermes:73f17f45ddf3
+```
+
+---
+
+## Create Sandbox Tool
+
+### Option A: Create via CLI
+
+Instead of filling in the console manually, you can create the sandbox tool with a single command. First, uncomment and fill in the `Create sandbox tool` section in `localproxy/.env`:
+
+| Variable | Required | Format / Example | Description |
+|----------|----------|------------------|-------------|
+| `IMAGE_ADDRESS` | Yes | `ccr.ccs.tencentyun.com/<namespace>/<image>:<tag>` | Full container image address including tag |
+| `IMAGE_REGISTRY_TYPE` | No | `personal` (default) or `enterprise` | `personal` = CCR, `enterprise` = TCR |
+| `CFS_FILE_SYSTEM_ID` | Yes | `cfs-xxxxxxxx` | CFS file system ID (find in [CFS console](https://console.cloud.tencent.com/cfs)) |
+| `CFS_PATH` | No | `/` (default) or `/<sub-path>` | Sub-path inside CFS to mount. Default `/` |
+| `ROLE_ARN` | Yes | `qcs::cam::uin/<owner-uin>:roleName/<role-name>` | CAM role ARN that AGS assumes to pull the image. The role must have CCR pull permissions. [Manage roles](https://console.cloud.tencent.com/cam/role) |
+
+Then run:
+
+```bash
+make create_sandbox_tool
+```
+
+This calls `CreateSandboxTool` via the AGS SDK with all the parameters documented below (startup command, probe, resources, CFS mount, etc.) pre-configured.
+
+### Option B: Create via AGS Console
+
+When creating a sandbox tool in the [AGS Console](https://console.cloud.tencent.com/ags), fill in the following:
+
+### Basic Configuration
+
+> **Important**: AGS ignores `CMD`/`ENTRYPOINT` in the image when running sandboxes. You must manually set the startup command and parameters in the console.
+
+| Field | Value |
+|-------|-------|
+| Tool Name | `my-hermes-agent` |
+| Tool Type | Custom Image |
+| Image Address | `ccr.ccs.tencentyun.com/your-namespace/sandbox-hermes:<hash>` |
+| Image Registry Type | Personal |
+| Startup Command | `/entrypoint.sh` |
+| Startup Parameters | (none) |
+| CPU | 4 cores |
+| Memory | 8 GiB |
+| Probe Path | `/health` |
+| Probe Port | `49983` |
+| Ready Timeout | `30000` ms |
+| Probe Interval | `3000` ms |
+| Failure Threshold | `100` |
+| Network Policy | Public |
+
+### Exposed Ports
+
+All three ports must be configured in the AGS console (click "Add" to create port entries):
+
+| Port Name | Port | Protocol |
+|-----------|------|----------|
+| `dashboard` | `9119` | TCP |
+| `gateway` | `8642` | TCP |
+| `envd` | `49983` | TCP |
+
+> **Important**: If ports are not explicitly exposed, the AGS gateway will return 500 for any request to those ports. The Hermes Dashboard (9119), Gateway (8642), and the envd daemon (49983, used for health probing) must all be exposed.
+
+### Environment Variables
+
+The following environment variables must be set in the AGS console (click "Add" to create entries):
+
+| Variable | Value | Description |
+|----------|-------|-------------|
+| `PYTHONUNBUFFERED` | `1` | Disable Python output buffering |
+| `HERMES_WEB_DIST` | `/opt/hermes/hermes_cli/web_dist` | Dashboard static assets path |
+| `PLAYWRIGHT_BROWSERS_PATH` | `/opt/hermes/.playwright` | Playwright browser binaries path |
+| `TERM` | `xterm` | Terminal type |
+| `SHLVL` | `1` | Shell level |
+| `HERMES_HOME` | `/opt/data` | Hermes data directory (must match CFS mount path) |
+| `PATH` | `/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` | System PATH including Hermes local bin |
+| `GATEWAY_ALLOW_ALL_USERS` | `true` | Allow all users to access the Gateway (required for AGS, otherwise all requests are denied) |
+
+> **Important**: `HERMES_HOME` must match the CFS mount path (`/opt/data`). Without these environment variables, Hermes may fail to start or the Dashboard may not render correctly.
+
+### Storage Mount Configuration
+
+| Mount Item | CFS ID | Container Mount Path |
+|------------|--------|---------------------|
+| Hermes Data | `cfs-xxxxxxxx` | `/opt/data` |
+
+> **Note**: CFS is mounted at `/opt/data`, which is the default `HERMES_HOME`. Hermes reads/writes all runtime data to this directory. CFS is a POSIX-compatible network filesystem — it supports all standard file operations including SQLite, file locking, symlinks, etc. On first boot, Hermes will automatically copy default config files (`.env`, `config.yaml`, `SOUL.md`) from the install directory.
+
+> **Note**: After updating the tool image, new sandboxes may return 502 for about 3 minutes. This is normal -- just retry later.
+
+---
+
+## Launch Sandbox and Access Dashboard
+
+### Configure Local Proxy
+
+Copy the environment variable template:
+
+```bash
+cp localproxy/.env.example localproxy/.env
+```
+
+Edit `localproxy/.env` with the following:
+
+```bash
+# Tencent Cloud API Credentials (required)
+TENCENTCLOUD_SECRET_ID=your_secret_id_here
+TENCENTCLOUD_SECRET_KEY=your_secret_key_here
+TENCENTCLOUD_REGION=ap-guangzhou          # AGS region
+
+# AGS Configuration (required)
+TOOL_NAME=my-hermes-agent               # Sandbox tool name created in AGS console
+
+# CFS Mount (optional, uses tool default mount if not set)
+MOUNT_NAME=cfs                           # Mount item name
+```
+
+Install dependencies and start:
+
+```bash
+# Run from the hermes-cookbook root directory
+make setup   # Install localproxy dependencies
+make run     # Start localproxy management service
+```
+
+### Usage Flow
+
+1. Open the management UI at **http://localhost:3001/_admin**
+2. Click **Start Sandbox** to create a new sandbox (or enter an existing sandbox ID and click **Connect**)
+3. Wait for state transitions: `Idle -> Starting -> Connecting -> Running`
+4. Once Running, click **Open Dashboard** to access Hermes Dashboard (at `http://localhost:3001/`)
+
+---
+
+## Persistent Storage
+
+Hermes uses the `HERMES_HOME` environment variable to determine where config and runtime data are stored. The default is:
+
+```
+HERMES_HOME=/opt/data
+```
+
+Simply mount the CFS file system to `/opt/data` in the container for persistence. CFS is a POSIX-compatible network filesystem — it behaves like a normal local filesystem and supports all standard operations (including SQLite, file locking, symlinks, etc.).
+
+Hermes reads/writes `/opt/data/`, which contains:
+
+| Path | Content |
+|------|---------|
+| `/opt/data/.env` | Environment config (auto-created on first boot) |
+| `/opt/data/config.yaml` | CLI config (auto-created on first boot) |
+| `/opt/data/SOUL.md` | Agent personality definition (auto-created on first boot) |
+| `/opt/data/sessions/` | Session data |
+| `/opt/data/skills/` | Skills data |
+| `/opt/data/memories/` | Memory data |
+| `/opt/data/logs/` | Log files |
+| `/opt/data/cron/` | Cron tasks |
+| `/opt/data/hooks/` | Hooks |
+| `/opt/data/workspace/` | Workspace files |
+
+> **Note**: Hermes does NOT require any pre-uploaded config files. On first boot, the entrypoint script automatically copies default configs from the install directory to `HERMES_HOME`.
+
+To isolate by user/session, set `CFS_PATH` to a sub-path (e.g. `/user-123`) when creating the sandbox tool, or enter a sub-path in the **Mount subpath** input field of the localproxy management UI:
+
+```
+CFS mount effect:
+cfs-xxxxxxxx:/user-123/    -> /opt/data
+```
+
+---
+
+## Logs and Debugging
+
+Log in to the sandbox using [ags-cli](https://github.com/TencentCloudAgentRuntime/ags-cli):
+
+```bash
+ags instance login <sandbox_id> --user root
+```
+
+Common debugging commands:
+
+```bash
+# Check process status
+ps aux | grep -E 'hermes|envd' | grep -v grep
+
+# Hermes Dashboard logs
+cat /logs/dashboard.log
+
+# Hermes Gateway logs
+cat /logs/gateway.log
+
+# Skills sync logs
+cat /logs/skills_sync.log
+
+# envd daemon logs
+cat /logs/envd.log
+```
+
+---
+
+## FAQ
+
+### Q1: Dashboard shows connection error
+
+**Cause**: Hermes Dashboard may not have started properly, or the `--host 0.0.0.0` flag is missing.
+
+**Solution**: Log into the sandbox and check `/logs/dashboard.log` for errors.
+
+### Q2: WebSocket connection intercepted
+
+**Solution**: You must access via `localproxy` local proxy. Do not access the AGS external URL directly.
+
+### Q3: How to update Hermes version
+
+Update the base image tag in the `Dockerfile`:
+
+```dockerfile
+FROM nousresearch/hermes-agent:v2026.4.23
+```
+
+Then rebuild and push:
+
+```bash
+cd hermes-cookbook
+make push
+```
+
+Then update the tool image in the AGS console with the new hash tag.
+

--- a/examples/hermes-cookbook/README_zh.md
+++ b/examples/hermes-cookbook/README_zh.md
@@ -1,0 +1,342 @@
+# Hermes Agent 沙箱使用指南
+
+基于官方 `nousresearch/hermes-agent` 镜像，在腾讯云 AGS 中运行 Hermes Agent。Hermes 首次启动时自动使用默认配置，无需预上传配置文件。
+
+---
+
+## 目录
+
+1. [架构概述](#架构概述)
+2. [前置准备](#前置准备)
+3. [构建并推送镜像](#构建并推送镜像)
+4. [创建沙箱工具](#创建沙箱工具)
+5. [启动沙箱并访问 Dashboard](#启动沙箱并访问-dashboard)
+6. [持久化存储](#持久化存储)
+7. [日志与调试](#日志与调试)
+8. [常见问题](#常见问题)
+
+---
+
+## 架构概述
+
+```
+浏览器
+  |
+  +- http://localhost:3001/_admin     <-- localproxy 管理界面（创建/连接/停止沙箱）
+  |
+  +- http://localhost:3001/           <-- 反向代理到 Hermes Dashboard（沙箱运行时）
+       |  自动注入 X-Access-Token Header
+       v
+  AGS 鉴权网关（<region>.tencentags.com）
+       |  验证 X-Access-Token
+       v
+  Hermes Dashboard:9119（--host 0.0.0.0, --insecure）
+```
+
+**容器内部结构：**
+
+| 进程 | 端口 | 作用 |
+|------|------|------|
+| `envd` | 49983 | AGS 沙箱管理守护进程（健康探针、命令执行） |
+| `hermes dashboard` | 9119 | Hermes Dashboard，`--host 0.0.0.0` 监听所有网络接口 |
+| `hermes gateway` | 8642 | Hermes Gateway（Agent 执行、Hooks） |
+
+---
+
+## 前置准备
+
+### 工具依赖
+
+| 工具 | 用途 | 安装方式 |
+|------|------|----------|
+| `podman` 或 `docker` | 构建/推送镜像 | [podman.io](https://podman.io) / [docker.com](https://docker.com) |
+| `Node.js >= 20` | 运行本地代理 | [nodejs.org](https://nodejs.org) |
+| `pnpm` | 包管理器 | `npm install -g pnpm` |
+
+### 凭据准备
+
+localproxy 使用腾讯云 AGS SDK 管理沙箱，需要以下凭据：
+
+| 凭据 | 说明 | 获取方式 |
+|------|------|----------|
+| `TENCENTCLOUD_SECRET_ID` | 腾讯云 API 密钥 ID | [API 密钥管理](https://console.cloud.tencent.com/cam/capi) |
+| `TENCENTCLOUD_SECRET_KEY` | 腾讯云 API 密钥 Key | 同上 |
+
+登录镜像仓库：
+
+```bash
+podman login ccr.ccs.tencentyun.com
+```
+
+---
+
+## 构建并推送镜像
+
+### 目录结构
+
+```
+hermes-cookbook/
++-- .env.example        # 环境变量模板（make setup 时自动复制到 localproxy/.env）
++-- .gitignore
++-- Dockerfile          # FROM 官方镜像，COPY --from AGS envd 镜像，自定义 entrypoint
++-- Makefile
++-- README.md           # 英文文档
++-- README_zh.md        # 中文文档（本文件）
++-- localproxy/         # 本地管理工具（创建/连接/停止沙箱 + 反向代理）
+    +-- .env.example    # 环境变量模板
+    +-- .gitignore
+    +-- README.md       # LocalProxy 文档（英文）
+    +-- README_zh.md    # LocalProxy 文档（中文）
+    +-- package.json
+    +-- pnpm-lock.yaml
+    +-- create-tool.ts  # 通过 AGS SDK 创建沙箱工具的脚本
+    +-- server.ts       # 主服务：Express + 状态机 + SSE + 内嵌 Web UI
+```
+
+### 构建与推送
+
+> **重要**：AGS 运行环境为 `linux/amd64`，必须构建 amd64 镜像。Makefile 已默认指定 `--platform linux/amd64`，在 Apple Silicon Mac 上构建时会自动交叉编译。
+
+> Makefile 默认使用 `podman`。Docker 用户可通过 `make push CONTAINER_ENGINE=docker` 覆盖。
+
+```bash
+cd hermes-cookbook
+
+make setup   # 从模板创建 localproxy/.env
+
+# 在 localproxy/.env 中设置 DOCKER_REGISTRY
+# DOCKER_REGISTRY=ccr.ccs.tencentyun.com/your-namespace
+
+# 构建并推送（同时推送 latest 和 hash 两个 tag）
+make push
+# 输出示例：
+# Pushed: ccr.ccs.tencentyun.com/your-namespace/sandbox-hermes:latest
+# Pushed: ccr.ccs.tencentyun.com/your-namespace/sandbox-hermes:73f17f45ddf3
+```
+
+---
+
+## 创建沙箱工具
+
+### 方式 A：通过命令行创建
+
+无需手动在控制台填写，只需一条命令即可创建沙箱工具。首先在 `localproxy/.env` 中取消注释并填写 `Create sandbox tool` 部分：
+
+| 变量 | 必填 | 格式 / 示例 | 说明 |
+|------|------|-------------|------|
+| `IMAGE_ADDRESS` | 是 | `ccr.ccs.tencentyun.com/<namespace>/<image>:<tag>` | 完整的容器镜像地址（含 tag） |
+| `IMAGE_REGISTRY_TYPE` | 否 | `personal`（默认）或 `enterprise` | `personal` = CCR 个人版，`enterprise` = TCR 企业版 |
+| `CFS_FILE_SYSTEM_ID` | 是 | `cfs-xxxxxxxx` | CFS 文件系统 ID（在 [CFS 控制台](https://console.cloud.tencent.com/cfs) 查看） |
+| `CFS_PATH` | 否 | `/`（默认）或 `/<sub-path>` | CFS 内挂载的子路径，默认 `/` |
+| `ROLE_ARN` | 是 | `qcs::cam::uin/<owner-uin>:roleName/<role-name>` | AGS 拉取镜像时扮演的 CAM 角色 ARN。该角色需有 CCR 拉取权限。[管理角色](https://console.cloud.tencent.com/cam/role) |
+
+然后执行：
+
+```bash
+make create_sandbox_tool
+```
+
+该命令通过 AGS SDK 调用 `CreateSandboxTool`，自动填入下方文档中的所有参数（启动命令、探针、资源规格、CFS 挂载等）。
+
+### 方式 B：通过 AGS 控制台创建
+
+在 [AGS 控制台](https://console.cloud.tencent.com/ags) 创建沙箱工具时，填写以下配置：
+
+### 基本配置
+
+> **重要**：AGS 运行沙箱时会忽略镜像内的 `CMD`/`ENTRYPOINT`，必须在控制台手动填写启动命令和启动参数。
+
+| 字段 | 值 |
+|------|----|
+| 工具名称 | `my-hermes-agent` |
+| 工具类型 | 自定义镜像 |
+| 镜像地址 | `ccr.ccs.tencentyun.com/your-namespace/sandbox-hermes:<hash>` |
+| 镜像仓库类型 | 个人版 |
+| 启动命令 | `/entrypoint.sh` |
+| 启动参数 | （无） |
+| CPU | 4 核 |
+| 内存 | 8 GiB |
+| 探针路径 | `/health` |
+| 探针端口 | `49983` |
+| 就绪超时 | `30000` ms |
+| 探针周期 | `3000` ms |
+| 失败阈值 | `100` |
+| 网络策略 | 公网 |
+
+### 端口开放配置
+
+以下三个端口都必须在 AGS 控制台中配置（点击「新增」添加端口条目）：
+
+| 端口名称 | 端口 | 协议 |
+|----------|------|------|
+| `dashboard` | `9119` | TCP |
+| `gateway` | `8642` | TCP |
+| `envd` | `49983` | TCP |
+
+> **重要**：如果端口未显式开放，AGS 网关会对该端口的所有请求返回 500。Hermes Dashboard（9119）、Gateway（8642）和 envd 守护进程（49983，用于健康探针）这三个端口都必须开放。
+
+### 环境变量配置
+
+以下环境变量必须在 AGS 控制台中设置（点击「新增」添加条目）：
+
+| 变量 | 值 | 说明 |
+|------|-----|------|
+| `PYTHONUNBUFFERED` | `1` | 禁用 Python 输出缓冲 |
+| `HERMES_WEB_DIST` | `/opt/hermes/hermes_cli/web_dist` | Dashboard 静态资源路径 |
+| `PLAYWRIGHT_BROWSERS_PATH` | `/opt/hermes/.playwright` | Playwright 浏览器二进制路径 |
+| `TERM` | `xterm` | 终端类型 |
+| `SHLVL` | `1` | Shell 层级 |
+| `HERMES_HOME` | `/opt/data` | Hermes 数据目录（必须与 CFS 挂载路径一致） |
+| `PATH` | `/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` | 系统 PATH，包含 Hermes 本地 bin 目录 |
+| `GATEWAY_ALLOW_ALL_USERS` | `true` | 允许所有用户访问 Gateway（AGS 环境必须，否则所有请求都会被拒绝） |
+
+> **重要**：`HERMES_HOME` 必须与 CFS 挂载路径（`/opt/data`）一致。缺少这些环境变量可能导致 Hermes 无法启动或 Dashboard 无法正常渲染。
+
+### 存储挂载配置
+
+| 挂载项 | CFS ID | 容器内挂载路径 |
+|--------|--------|---------------|
+| Hermes 数据 | `cfs-xxxxxxxx` | `/opt/data` |
+
+> **注意**：CFS 挂载路径为 `/opt/data`，即默认的 `HERMES_HOME`。Hermes 会将所有运行时数据写入该目录。CFS 是 POSIX 兼容的网络文件系统，支持所有标准文件操作（包括 SQLite、文件锁、符号链接等）。首次启动时，entrypoint 脚本会自动从安装目录复制默认配置文件（`.env`、`config.yaml`、`SOUL.md`）。
+
+> **注意**：更新工具镜像后约 3 分钟内新建沙箱可能返回 502，属正常现象，稍后重试即可。
+
+---
+
+## 启动沙箱并访问 Dashboard
+
+### 配置本地代理
+
+复制环境变量模板：
+
+```bash
+cp localproxy/.env.example localproxy/.env
+```
+
+编辑 `localproxy/.env`，填入以下环境变量：
+
+```bash
+# 腾讯云 API 凭据（必须）
+TENCENTCLOUD_SECRET_ID=your_secret_id_here
+TENCENTCLOUD_SECRET_KEY=your_secret_key_here
+TENCENTCLOUD_REGION=ap-guangzhou          # AGS 所在地域
+
+# AGS 配置（必须）
+TOOL_NAME=my-hermes-agent               # AGS 控制台创建的沙箱工具名称
+
+# CFS 挂载（可选，不填则使用工具配置的默认挂载）
+MOUNT_NAME=cfs                           # 指定挂载项名称
+```
+
+安装依赖并启动：
+
+```bash
+# 在 hermes-cookbook 根目录下执行
+make setup   # 安装 localproxy 依赖
+make run     # 启动 localproxy 管理服务
+```
+
+### 使用流程
+
+1. 打开管理界面 **http://localhost:3001/_admin**
+2. 点击 **Start Sandbox** 创建新沙箱（或在输入框填入已有沙箱 ID 后点击 **Connect**）
+3. 等待状态流转：`Idle -> Starting -> Connecting -> Running`
+4. Running 后，点击 **Open Dashboard** 访问 Hermes Dashboard（地址为 `http://localhost:3001/`）
+
+---
+
+## 持久化存储
+
+Hermes 通过 `HERMES_HOME` 环境变量决定配置和运行时数据的存储位置，默认为：
+
+```
+HERMES_HOME=/opt/data
+```
+
+只需将 CFS 文件系统挂载到容器的 `/opt/data` 路径即可实现持久化。CFS 是 POSIX 兼容的网络文件系统，使用方式与本地文件系统完全一致，支持所有标准文件操作（包括 SQLite、文件锁、符号链接等）。
+
+Hermes 会读写 `/opt/data/`，包含：
+
+| 路径 | 内容 |
+|------|------|
+| `/opt/data/.env` | 环境配置（首次启动自动创建） |
+| `/opt/data/config.yaml` | CLI 配置（首次启动自动创建） |
+| `/opt/data/SOUL.md` | Agent 人设定义（首次启动自动创建） |
+| `/opt/data/sessions/` | 会话数据 |
+| `/opt/data/skills/` | 技能数据 |
+| `/opt/data/memories/` | 记忆数据 |
+| `/opt/data/logs/` | 日志文件 |
+| `/opt/data/cron/` | Cron 任务 |
+| `/opt/data/hooks/` | Hooks |
+| `/opt/data/workspace/` | 工作区文件 |
+
+> **注意**：Hermes **不需要**预先上传配置文件。首次启动时，entrypoint 脚本会自动从安装目录复制默认配置到 `HERMES_HOME`。
+
+如需按用户/会话隔离，可在创建沙箱工具时设置 `CFS_PATH` 为子路径（如 `/user-123`），或在 localproxy 管理界面的 **Mount subpath** 输入框中填写子路径：
+
+```
+CFS 挂载效果：
+cfs-xxxxxxxx:/user-123/    -> /opt/data
+```
+
+---
+
+## 日志与调试
+
+使用 [ags-cli](https://github.com/TencentCloudAgentRuntime/ags-cli) 登录沙箱：
+
+```bash
+ags instance login <sandbox_id> --user root
+```
+
+常用调试命令：
+
+```bash
+# 查看进程状态
+ps aux | grep -E 'hermes|envd' | grep -v grep
+
+# Hermes Dashboard 日志
+cat /logs/dashboard.log
+
+# Hermes Gateway 日志
+cat /logs/gateway.log
+
+# 技能同步日志
+cat /logs/skills_sync.log
+
+# envd 守护进程日志
+cat /logs/envd.log
+```
+
+---
+
+## 常见问题
+
+### Q1：Dashboard 打开后显示连接错误
+
+**原因**：Hermes Dashboard 可能未正常启动，或缺少 `--host 0.0.0.0` 参数。
+
+**解决**：登录沙箱检查 `/logs/dashboard.log` 中的错误信息。
+
+### Q2：WebSocket 连接被拦截
+
+**解决**：必须通过 `localproxy` 本地代理访问，不要直接访问 AGS 外部 URL。
+
+### Q3：如何更新 Hermes 版本
+
+更新 `Dockerfile` 中的基础镜像 tag：
+
+```dockerfile
+FROM nousresearch/hermes-agent:v2026.4.23
+```
+
+然后重新构建并推送：
+
+```bash
+cd hermes-cookbook
+make push
+```
+
+然后在 AGS 控制台更新工具镜像为新的 hash tag。
+

--- a/examples/hermes-cookbook/localproxy/.env.example
+++ b/examples/hermes-cookbook/localproxy/.env.example
@@ -1,0 +1,37 @@
+# ============================================================================
+# Hermes Cookbook Configuration
+# ============================================================================
+# Copy this file to localproxy/.env and fill in your values:
+#   cp .env.example localproxy/.env
+#
+# This file is used by both Makefile (build/push) and localproxy (create-tool/run).
+# ============================================================================
+
+# --- Tencent Cloud API credentials (required) ---
+TENCENTCLOUD_SECRET_ID=your_secret_id_here
+TENCENTCLOUD_SECRET_KEY=your_secret_key_here
+TENCENTCLOUD_REGION=ap-guangzhou
+
+# --- Image registry (required for build/push) ---
+# Full registry path, e.g. ccr.ccs.tencentyun.com/your-namespace
+DOCKER_REGISTRY=ccr.ccs.tencentyun.com/your-namespace
+
+# --- AGS sandbox tool (required for create-tool/run) ---
+TOOL_NAME=my-hermes-agent
+
+# --- Storage mount (required for create-tool) ---
+# CFS file system ID (find in https://console.cloud.tencent.com/cfs)
+CFS_FILE_SYSTEM_ID=cfs-xxxxxxxx
+
+# --- IAM role (required for create-tool) ---
+# CAM role ARN for AGS to pull image (https://console.cloud.tencent.com/cam/role)
+ROLE_ARN=qcs::cam::uin/100000000000:roleName/your-ags-role
+
+# --- Optional overrides (uncomment to customize) ---
+# APP_NAME=sandbox-hermes
+# VERSION=latest
+# CONTAINER_ENGINE=podman
+# MOUNT_NAME=cfs
+# CFS_PATH=/
+# IMAGE_ADDRESS=ccr.ccs.tencentyun.com/your-namespace/sandbox-hermes:latest
+# IMAGE_REGISTRY_TYPE=personal

--- a/examples/hermes-cookbook/localproxy/.gitignore
+++ b/examples/hermes-cookbook/localproxy/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+dist

--- a/examples/hermes-cookbook/localproxy/README.md
+++ b/examples/hermes-cookbook/localproxy/README.md
@@ -1,0 +1,165 @@
+# LocalProxy
+
+Local management tool for Hermes Agent sandboxes. Create, connect, pause, and resume sandboxes via a browser UI, with the in-sandbox Hermes Dashboard reverse-proxied to localhost.
+
+---
+
+## Architecture
+
+```
+pnpm dev / pnpm start
+  +- tsx server.ts
+       +- Express :3001
+            +-- GET /_admin              Management UI (embedded HTML + CSS + JS, no build step)
+            +-- GET /_admin/api/status   Current state snapshot
+            +-- GET /_admin/api/events   SSE real-time push
+            +-- POST /_admin/api/start   Create new sandbox
+            +-- POST /_admin/api/stop    Stop and destroy sandbox
+            +-- POST /_admin/api/pause   Pause sandbox
+            +-- POST /_admin/api/resume  Resume sandbox
+            +-- POST /_admin/api/connect Connect to existing sandbox
+            +-- /* (catch-all)           Reverse proxy to Hermes Dashboard (when running)
+
+http://localhost:3001/  ->  Hermes Dashboard (when sandbox is running)
+http://localhost:3001/  ->  Redirects to /_admin (when sandbox is not running)
+```
+
+The entire project is a **single file** (`server.ts`) -- HTML, CSS, and client-side JS are all embedded. No build step needed; just run `tsx server.ts`.
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- Node.js >= 20
+- pnpm
+- Tencent Cloud API credentials (SecretId / SecretKey)
+
+### Install
+
+```bash
+pnpm install
+```
+
+### Configure
+
+Copy and edit `.env`:
+
+```bash
+cp .env.example .env
+```
+
+```env
+# Tencent Cloud API credentials (required)
+TENCENTCLOUD_SECRET_ID=your_secret_id_here
+TENCENTCLOUD_SECRET_KEY=your_secret_key_here
+TENCENTCLOUD_REGION=ap-guangzhou
+
+# AGS configuration (required)
+TOOL_NAME=my-hermes-agent
+
+# CFS mount (optional, uses tool default mount if not set)
+MOUNT_NAME=cfs
+```
+
+### Run
+
+```bash
+# Development mode (auto-restart on file changes)
+pnpm dev
+
+# Production mode
+pnpm start
+```
+
+Then open **http://localhost:3001/_admin**.
+
+---
+
+## Usage
+
+### Create a New Sandbox
+
+1. Open http://localhost:3001/_admin
+2. (Optional) Enter a CFS sub-path in the **Mount subpath** field
+3. Click **Start Sandbox**
+4. State transitions: `Idle -> Starting -> Connecting -> Running`
+5. Once Running, click **Open Dashboard** to access Hermes Dashboard (at `http://localhost:3001/`)
+6. Click **Stop Sandbox** to stop and destroy the sandbox
+
+### Connect to an Existing Sandbox
+
+1. Enter the Sandbox ID in the **Connect to existing sandbox** field
+2. Click **Connect** (or press Enter)
+3. Once connected, the state becomes Running
+4. Stopping only closes the local proxy -- the remote sandbox is **not destroyed**
+
+### Pause / Resume
+
+- While Running, click **Pause** to pause the sandbox (frees compute resources, preserves state)
+- While Paused, click **Resume** to resume the sandbox
+
+---
+
+## Ports
+
+| Port | Purpose |
+|------|---------|
+| 3001 | Management UI (`/_admin`) + API (`/_admin/api`) + Hermes Dashboard proxy (all other paths) |
+
+---
+
+## State Machine
+
+```
+idle --start--> starting --> connecting --> running --pause--> pausing --> paused
+ ^                                             |                            |
+ +------------------ stop <--------------------+                            |
+ ^                                                                          |
+ +------------------ stop <-------------------------------------------------+
+
+idle --connect--> connecting --> running
+
+paused --resume--> resuming --> running
+```
+
+| State | Meaning |
+|-------|---------|
+| `idle` | No sandbox, waiting for action |
+| `starting` | Creating sandbox |
+| `connecting` | Sandbox created/specified, waiting for Hermes to be ready |
+| `running` | Proxy started, service available |
+| `pausing` | Pausing sandbox |
+| `paused` | Sandbox paused |
+| `resuming` | Resuming sandbox |
+| `stopping` | Closing proxy and (depending on mode) destroying sandbox |
+
+---
+
+## Project Structure
+
+```
+localproxy/
++-- .env.example     # Environment variable template
++-- .gitignore
++-- README.md        # This file (English)
++-- README_zh.md     # Chinese version
++-- package.json
++-- pnpm-lock.yaml
++-- create-tool.ts   # Script to create sandbox tool via AGS SDK
++-- server.ts        # All logic: Express server, state machine, SSE, embedded UI
+```
+
+---
+
+## Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `tencentcloud-sdk-nodejs-ags` | Tencent Cloud AGS SDK (create/stop/pause/resume sandbox) |
+| `express` | HTTP server |
+| `cors` | CORS headers |
+| `dotenv` | Environment variable loading |
+| `http-proxy` | Reverse proxy |
+| `tsx` | Run TypeScript directly, no compilation needed |

--- a/examples/hermes-cookbook/localproxy/README_zh.md
+++ b/examples/hermes-cookbook/localproxy/README_zh.md
@@ -1,0 +1,165 @@
+# LocalProxy
+
+Hermes Agent 沙箱本地管理工具。通过浏览器界面创建、连接、暂停和恢复沙箱，并将沙箱内的 Hermes Dashboard 反向代理到本地。
+
+---
+
+## 架构
+
+```
+pnpm dev / pnpm start
+  +- tsx server.ts
+       +- Express :3001
+            +-- GET /_admin              管理界面（内嵌 HTML + CSS + JS，无需构建）
+            +-- GET /_admin/api/status   当前状态快照
+            +-- GET /_admin/api/events   SSE 实时推送
+            +-- POST /_admin/api/start   创建新沙箱
+            +-- POST /_admin/api/stop    停止并销毁沙箱
+            +-- POST /_admin/api/pause   暂停沙箱
+            +-- POST /_admin/api/resume  恢复沙箱
+            +-- POST /_admin/api/connect 连接已有沙箱
+            +-- /* (兜底)                反向代理到 Hermes Dashboard（运行时）
+
+http://localhost:3001/  ->  Hermes Dashboard（沙箱运行时）
+http://localhost:3001/  ->  重定向到 /_admin（沙箱未运行时）
+```
+
+整个项目是一个**单文件**（`server.ts`）—— HTML、CSS 和客户端 JS 都内嵌其中。无需构建步骤，直接运行 `tsx server.ts` 即可。
+
+---
+
+## 快速开始
+
+### 前置条件
+
+- Node.js >= 20
+- pnpm
+- 腾讯云 API 凭据（SecretId / SecretKey）
+
+### 安装
+
+```bash
+pnpm install
+```
+
+### 配置
+
+复制并编辑 `.env`：
+
+```bash
+cp .env.example .env
+```
+
+```env
+# 腾讯云 API 凭据（必须）
+TENCENTCLOUD_SECRET_ID=your_secret_id_here
+TENCENTCLOUD_SECRET_KEY=your_secret_key_here
+TENCENTCLOUD_REGION=ap-guangzhou
+
+# AGS 配置（必须）
+TOOL_NAME=my-hermes-agent
+
+# CFS 挂载（可选，不填则使用工具配置的默认挂载）
+MOUNT_NAME=cfs
+```
+
+### 运行
+
+```bash
+# 开发模式（文件修改后自动重启）
+pnpm dev
+
+# 生产模式
+pnpm start
+```
+
+然后打开 **http://localhost:3001/_admin**。
+
+---
+
+## 使用方式
+
+### 创建新沙箱
+
+1. 打开 http://localhost:3001/_admin
+2. （可选）在 **Mount subpath** 输入框中填写 CFS 子路径
+3. 点击 **Start Sandbox**
+4. 状态流转：`Idle -> Starting -> Connecting -> Running`
+5. Running 后，点击 **Open Dashboard** 访问 Hermes Dashboard（地址为 `http://localhost:3001/`）
+6. 点击 **Stop Sandbox** 停止并销毁沙箱
+
+### 连接已有沙箱
+
+1. 在 **Connect to existing sandbox** 输入框中填写沙箱 ID
+2. 点击 **Connect**（或按回车）
+3. 连接成功后状态变为 Running
+4. 停止时仅关闭本地代理——远程沙箱**不会被销毁**
+
+### 暂停 / 恢复
+
+- Running 状态下点击 **Pause** 暂停沙箱（释放计算资源，保留状态）
+- Paused 状态下点击 **Resume** 恢复沙箱
+
+---
+
+## 端口
+
+| 端口 | 用途 |
+|------|------|
+| 3001 | 管理界面（`/_admin`）+ API（`/_admin/api`）+ Hermes Dashboard 代理（所有其他路径） |
+
+---
+
+## 状态机
+
+```
+idle --start--> starting --> connecting --> running --pause--> pausing --> paused
+ ^                                             |                            |
+ +------------------ stop <--------------------+                            |
+ ^                                                                          |
+ +------------------ stop <-------------------------------------------------+
+
+idle --connect--> connecting --> running
+
+paused --resume--> resuming --> running
+```
+
+| 状态 | 含义 |
+|------|------|
+| `idle` | 无沙箱，等待操作 |
+| `starting` | 创建沙箱中 |
+| `connecting` | 沙箱已创建/指定，等待 Hermes 就绪 |
+| `running` | 代理已启动，服务可用 |
+| `pausing` | 暂停沙箱中 |
+| `paused` | 沙箱已暂停 |
+| `resuming` | 恢复沙箱中 |
+| `stopping` | 关闭代理并（根据模式）销毁沙箱 |
+
+---
+
+## 项目结构
+
+```
+localproxy/
++-- .env.example     # 环境变量模板
++-- .gitignore
++-- README.md        # 英文文档
++-- README_zh.md     # 中文文档（本文件）
++-- package.json
++-- pnpm-lock.yaml
++-- create-tool.ts   # 通过 AGS SDK 创建沙箱工具的脚本
++-- server.ts        # 所有逻辑：Express 服务器、状态机、SSE、内嵌 UI
+```
+
+---
+
+## 依赖
+
+| 包 | 用途 |
+|----|------|
+| `tencentcloud-sdk-nodejs-ags` | 腾讯云 AGS SDK（创建/停止/暂停/恢复沙箱） |
+| `express` | HTTP 服务器 |
+| `cors` | CORS 头 |
+| `dotenv` | 环境变量加载 |
+| `http-proxy` | 反向代理 |
+| `tsx` | 直接运行 TypeScript，无需编译 |

--- a/examples/hermes-cookbook/localproxy/create-tool.ts
+++ b/examples/hermes-cookbook/localproxy/create-tool.ts
@@ -1,0 +1,105 @@
+import 'dotenv/config';
+import { ags } from 'tencentcloud-sdk-nodejs-ags';
+
+const AgsClient = ags.v20250920.Client;
+
+const VALID_REGISTRY_TYPES = ['personal', 'enterprise'] as const;
+
+function requireEnv(name: string): string {
+  const val = process.env[name];
+  if (!val) throw new Error(`Missing required environment variable: ${name}`);
+  return val;
+}
+
+async function main() {
+  const secretId = requireEnv('TENCENTCLOUD_SECRET_ID');
+  const secretKey = requireEnv('TENCENTCLOUD_SECRET_KEY');
+  const region = process.env.TENCENTCLOUD_REGION || 'ap-guangzhou';
+  const toolName = requireEnv('TOOL_NAME');
+  const dockerRegistry = process.env.DOCKER_REGISTRY;
+  const appName = process.env.APP_NAME || 'sandbox-hermes';
+  const imageAddress = process.env.IMAGE_ADDRESS
+    || (dockerRegistry ? `${dockerRegistry}/${appName}:latest` : '');
+  if (!imageAddress) throw new Error('Missing IMAGE_ADDRESS or DOCKER_REGISTRY in .env');
+  const imageRegistryType = process.env.IMAGE_REGISTRY_TYPE || 'personal';
+  const cfsFileSystemId = requireEnv('CFS_FILE_SYSTEM_ID');
+  const cfsPath = process.env.CFS_PATH || '/';
+  const roleArn = requireEnv('ROLE_ARN');
+  const mountName = process.env.MOUNT_NAME || 'cfs';
+
+  if (!(VALID_REGISTRY_TYPES as readonly string[]).includes(imageRegistryType)) {
+    throw new Error(`IMAGE_REGISTRY_TYPE must be 'personal' or 'enterprise', got: '${imageRegistryType}'`);
+  }
+
+  const client = new AgsClient({
+    credential: { secretId, secretKey },
+    region,
+  });
+
+  console.log(`Creating sandbox tool "${toolName}" in ${region}...`);
+  console.log(`   Image: ${imageAddress} (${imageRegistryType})`);
+  console.log(`   CFS:   ${cfsFileSystemId}:${cfsPath} -> /opt/data`);
+
+  const resp = await client.CreateSandboxTool({
+    ToolName: toolName,
+    ToolType: 'custom',
+    RoleArn: roleArn,
+    NetworkConfiguration: { NetworkMode: 'PUBLIC' },
+    CustomConfiguration: {
+      Image: imageAddress,
+      ImageRegistryType: imageRegistryType,
+      Command: ['/entrypoint.sh'],
+      Args: [],
+      Env: [
+        { Name: 'PYTHONUNBUFFERED', Value: '1' },
+        { Name: 'HERMES_WEB_DIST', Value: '/opt/hermes/hermes_cli/web_dist' },
+        { Name: 'PLAYWRIGHT_BROWSERS_PATH', Value: '/opt/hermes/.playwright' },
+        { Name: 'TERM', Value: 'xterm' },
+        { Name: 'SHLVL', Value: '1' },
+        { Name: 'HERMES_HOME', Value: '/opt/data' },
+        { Name: 'PATH', Value: '/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' },
+        { Name: 'GATEWAY_ALLOW_ALL_USERS', Value: 'true' },
+      ],
+      Ports: [
+        { Name: 'dashboard', Port: 9119, Protocol: 'TCP' },
+        { Name: 'gateway', Port: 8642, Protocol: 'TCP' },
+        { Name: 'envd', Port: 49983, Protocol: 'TCP' },
+      ],
+      Resources: { CPU: '4', Memory: '8Gi' },
+      Probe: {
+        HttpGet: { Path: '/health', Port: 49983, Scheme: 'HTTP' },
+        ReadyTimeoutMs: 30000,
+        ProbeTimeoutMs: 1000,
+        ProbePeriodMs: 3000,
+        SuccessThreshold: 1,
+        FailureThreshold: 100,
+      },
+    },
+    StorageMounts: [
+      {
+        Name: mountName,
+        MountPath: '/opt/data',
+        StorageSource: {
+          Cfs: {
+            FileSystemId: cfsFileSystemId,
+            Path: cfsPath,
+          },
+        },
+      },
+    ],
+  });
+
+  console.log(`Sandbox tool created successfully!`);
+  console.log(`   Tool ID:   ${resp.ToolId ?? '(check AGS console)'}`);
+  console.log(`   Tool Name: ${toolName}`);
+  console.log(`   Mount:     ${mountName} (CFS ${cfsFileSystemId}) -> /opt/data`);
+}
+
+main().catch((err) => {
+  if (err.code?.startsWith('ResourceInUse') || err.message?.includes('already exists')) {
+    console.error(`Tool "${process.env.TOOL_NAME}" already exists. Delete it first or use a different TOOL_NAME.`);
+  } else {
+    console.error('Failed to create sandbox tool:', err);
+  }
+  process.exit(1);
+});

--- a/examples/hermes-cookbook/localproxy/package.json
+++ b/examples/hermes-cookbook/localproxy/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "localproxy",
+  "version": "1.0.0",
+  "description": "LocalProxy — Hermes Agent Sandbox Manager",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch server.ts",
+    "start": "tsx server.ts",
+    "create-tool": "tsx create-tool.ts"
+  },
+  "dependencies": {
+    "tencentcloud-sdk-nodejs-ags": "^4.1.199",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "http-proxy": "^1.18.1"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/http-proxy": "^1.17.17",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.3"
+  },
+  "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
+  }
+}

--- a/examples/hermes-cookbook/localproxy/pnpm-lock.yaml
+++ b/examples/hermes-cookbook/localproxy/pnpm-lock.yaml
@@ -1,0 +1,1260 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.6
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.6.1
+      express:
+        specifier: ^4.18.2
+        version: 4.22.1
+      http-proxy:
+        specifier: ^1.18.1
+        version: 1.18.1
+      tencentcloud-sdk-nodejs-ags:
+        specifier: ^4.1.199
+        version: 4.1.199
+    devDependencies:
+      '@types/cors':
+        specifier: ^2.8.17
+        version: 2.8.19
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.25
+      '@types/http-proxy':
+        specifier: ^1.17.17
+        version: 1.17.17
+      tsx:
+        specifier: ^4.7.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.4':
+    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.4':
+    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.4':
+    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.4':
+    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.4':
+    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.4':
+    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.4':
+    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.4':
+    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.4':
+    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.4':
+    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.4':
+    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.4':
+    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.4':
+    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.4':
+    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.4':
+    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.4':
+    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.4':
+    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.4':
+    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.4':
+    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.4':
+    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.4':
+    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.4':
+    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.4':
+    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
+  '@types/express-serve-static-core@4.19.8':
+    resolution: {integrity: sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==}
+
+  '@types/express@4.17.25':
+    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/http-proxy@1.17.17':
+    resolution: {integrity: sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==}
+
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
+  '@types/node@25.5.0':
+    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+
+  '@types/qs@6.15.0':
+    resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@0.17.6':
+    resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@1.15.10':
+    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
+
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  body-parser@1.20.4:
+    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.27.4:
+    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  express@4.22.1:
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
+    engines: {node: '>= 0.10.0'}
+
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
+    engines: {node: '>= 0.8'}
+
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@3.0.4:
+    resolution: {integrity: sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==}
+    engines: {node: '>= 6'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  http-proxy@1.18.1:
+    resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
+    engines: {node: '>=8.0.0'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@5.0.0:
+    resolution: {integrity: sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.14.2:
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  tencentcloud-sdk-nodejs-ags@4.1.199:
+    resolution: {integrity: sha512-BZqx7/AjrDCkkq+cmsKkZq7P0kvAEox2AzQYXPmAsYLkTA+LZPuDUjgrTzYFNgpX90igdcLrXxvK9Hm5mOaunQ==}
+    engines: {node: '>=10'}
+
+  tencentcloud-sdk-nodejs-common@4.1.122:
+    resolution: {integrity: sha512-bzZ2f289vJz36l8bU/RZQrsvdLo/MNsETQ3w9KjTKknP4xJrmO8F+RE0nBuyKiEF0p+SR9V29it39lfjGnb4qg==}
+    engines: {node: '>=10'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tslib@1.13.0:
+    resolution: {integrity: sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.4':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.4':
+    optional: true
+
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 25.5.0
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 25.5.0
+
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 25.5.0
+
+  '@types/express-serve-static-core@4.19.8':
+    dependencies:
+      '@types/node': 25.5.0
+      '@types/qs': 6.15.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@4.17.25':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 4.19.8
+      '@types/qs': 6.15.0
+      '@types/serve-static': 1.15.10
+
+  '@types/http-errors@2.0.5': {}
+
+  '@types/http-proxy@1.17.17':
+    dependencies:
+      '@types/node': 25.5.0
+
+  '@types/mime@1.3.5': {}
+
+  '@types/node@25.5.0':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/qs@6.15.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@0.17.6':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 25.5.0
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 25.5.0
+
+  '@types/serve-static@1.15.10':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 25.5.0
+      '@types/send': 0.17.6
+
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  array-flatten@1.1.1: {}
+
+  asynckit@0.4.0: {}
+
+  bignumber.js@9.3.1: {}
+
+  body-parser@1.20.4:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.14.2
+      raw-body: 2.5.3
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.0.7: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  delayed-stream@1.0.0: {}
+
+  depd@2.0.0: {}
+
+  destroy@1.2.0: {}
+
+  dotenv@16.6.1: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  esbuild@0.27.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.4
+      '@esbuild/android-arm': 0.27.4
+      '@esbuild/android-arm64': 0.27.4
+      '@esbuild/android-x64': 0.27.4
+      '@esbuild/darwin-arm64': 0.27.4
+      '@esbuild/darwin-x64': 0.27.4
+      '@esbuild/freebsd-arm64': 0.27.4
+      '@esbuild/freebsd-x64': 0.27.4
+      '@esbuild/linux-arm': 0.27.4
+      '@esbuild/linux-arm64': 0.27.4
+      '@esbuild/linux-ia32': 0.27.4
+      '@esbuild/linux-loong64': 0.27.4
+      '@esbuild/linux-mips64el': 0.27.4
+      '@esbuild/linux-ppc64': 0.27.4
+      '@esbuild/linux-riscv64': 0.27.4
+      '@esbuild/linux-s390x': 0.27.4
+      '@esbuild/linux-x64': 0.27.4
+      '@esbuild/netbsd-arm64': 0.27.4
+      '@esbuild/netbsd-x64': 0.27.4
+      '@esbuild/openbsd-arm64': 0.27.4
+      '@esbuild/openbsd-x64': 0.27.4
+      '@esbuild/openharmony-arm64': 0.27.4
+      '@esbuild/sunos-x64': 0.27.4
+      '@esbuild/win32-arm64': 0.27.4
+      '@esbuild/win32-ia32': 0.27.4
+      '@esbuild/win32-x64': 0.27.4
+
+  escape-html@1.0.3: {}
+
+  etag@1.8.1: {}
+
+  eventemitter3@4.0.7: {}
+
+  express@4.22.1:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.4
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.2
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.12
+      proxy-addr: 2.0.7
+      qs: 6.14.2
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.2
+      serve-static: 1.16.3
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  finalhandler@1.3.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  follow-redirects@1.15.11: {}
+
+  form-data@3.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-stream@6.0.1: {}
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  http-proxy@1.18.1:
+    dependencies:
+      eventemitter3: 4.0.7
+      follow-redirects: 1.15.11
+      requires-port: 1.0.0
+    transitivePeerDependencies:
+      - debug
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  ini@5.0.0: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-stream@2.0.1: {}
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@0.3.0: {}
+
+  merge-descriptors@1.0.3: {}
+
+  methods@1.1.2: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime@1.6.0: {}
+
+  ms@2.0.0: {}
+
+  ms@2.1.3: {}
+
+  negotiator@0.6.3: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  parseurl@1.3.3: {}
+
+  path-to-regexp@0.1.12: {}
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.14.2:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  requires-port@1.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  statuses@2.0.2: {}
+
+  tencentcloud-sdk-nodejs-ags@4.1.199:
+    dependencies:
+      tencentcloud-sdk-nodejs-common: 4.1.122
+      tslib: 1.13.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  tencentcloud-sdk-nodejs-common@4.1.122:
+    dependencies:
+      form-data: 3.0.4
+      get-stream: 6.0.1
+      https-proxy-agent: 5.0.1
+      ini: 5.0.0
+      is-stream: 2.0.1
+      json-bigint: 1.0.0
+      node-fetch: 2.7.0
+      tslib: 1.13.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  toidentifier@1.0.1: {}
+
+  tr46@0.0.3: {}
+
+  tslib@1.13.0: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.4
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
+  typescript@5.9.3: {}
+
+  undici-types@7.18.2: {}
+
+  unpipe@1.0.0: {}
+
+  utils-merge@1.0.1: {}
+
+  uuid@9.0.1: {}
+
+  vary@1.1.2: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1

--- a/examples/hermes-cookbook/localproxy/server.ts
+++ b/examples/hermes-cookbook/localproxy/server.ts
@@ -1,0 +1,1116 @@
+import 'dotenv/config';
+import express from 'express';
+import cors from 'cors';
+import http from 'http';
+import { ags } from 'tencentcloud-sdk-nodejs-ags';
+import httpProxy from 'http-proxy';
+
+const AgsClient = ags.v20250920.Client;
+
+// ---------------------------------------------------------------------------
+// Startup validation
+// ---------------------------------------------------------------------------
+
+for (const key of ['TENCENTCLOUD_SECRET_ID', 'TENCENTCLOUD_SECRET_KEY', 'TOOL_NAME']) {
+  if (!process.env[key]) {
+    console.error(`Error: Missing required environment variable: ${key}`);
+    console.error('Run "make setup" and fill in localproxy/.env with your credentials.');
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MANAGEMENT_PORT = 3001;
+const HERMES_DASHBOARD_PORT = 9119;
+const LOG_RING_BUFFER_SIZE = 200;
+
+// ---------------------------------------------------------------------------
+// State Machine
+// ---------------------------------------------------------------------------
+
+type SandboxStatus = 'idle' | 'starting' | 'connecting' | 'running' | 'pausing' | 'paused' | 'resuming' | 'stopping';
+type SandboxMode = 'created' | 'connected';
+
+interface SandboxState {
+  status: SandboxStatus;
+  mode?: SandboxMode;
+  sandboxId?: string;
+  startedAt?: number;
+  logs: string[];
+  error?: string;
+}
+
+let state: SandboxState = {
+  status: 'idle',
+  logs: [],
+};
+
+function appendLog(msg: string) {
+  state.logs.push(`[${new Date().toISOString()}] ${msg}`);
+  if (state.logs.length > LOG_RING_BUFFER_SIZE) {
+    state.logs = state.logs.slice(-LOG_RING_BUFFER_SIZE);
+  }
+  broadcast();
+  console.log(msg);
+}
+
+function setState(patch: Partial<SandboxState>) {
+  state = { ...state, ...patch };
+  broadcast();
+}
+
+// ---------------------------------------------------------------------------
+// SSE Broadcast
+// ---------------------------------------------------------------------------
+
+const sseClients = new Set<express.Response>();
+
+function broadcast() {
+  const data = JSON.stringify(state);
+  for (const res of sseClients) {
+    res.write(`data: ${data}\n\n`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Proxy (catch-all forwarding to sandbox)
+// ---------------------------------------------------------------------------
+
+let sandboxProxy: ReturnType<typeof httpProxy.createProxyServer> | null = null;
+let sandboxWsHandler: ((req: http.IncomingMessage, socket: any, head: Buffer) => void) | null = null;
+
+function startProxyServer(remoteHost: string, accessToken: string): void {
+  const proxy = httpProxy.createProxyServer({
+    target: `https://${remoteHost}`,
+    changeOrigin: true,
+    secure: true,
+    ws: true,
+  });
+
+  proxy.on('proxyReq', (proxyReq, _req) => {
+    proxyReq.setHeader('X-Access-Token', accessToken);
+  });
+
+  proxy.on('proxyReqWs', (proxyReq) => {
+    proxyReq.setHeader('X-Access-Token', accessToken);
+  });
+
+  proxy.on('proxyRes', (proxyRes) => {
+    delete proxyRes.headers['x-frame-options'];
+    delete proxyRes.headers['X-Frame-Options'];
+    delete proxyRes.headers['content-security-policy'];
+    delete proxyRes.headers['Content-Security-Policy'];
+  });
+
+  proxy.on('error', (err, _req, res) => {
+    appendLog(`Proxy error: ${err.message}`);
+    if (res && 'writeHead' in res) {
+      (res as http.ServerResponse).writeHead(502);
+      (res as http.ServerResponse).end('Bad Gateway: ' + err.message);
+    }
+  });
+
+  sandboxProxy = proxy;
+
+  // WebSocket upgrade forwarding
+  sandboxWsHandler = (req, socket, head) => {
+    // Don't proxy /_admin WebSocket connections
+    if (req.url?.startsWith('/_admin')) return;
+    socket.on('error', (err: Error) => appendLog(`WebSocket error: ${err.message}`));
+    proxy.ws(req, socket, head);
+  };
+
+  appendLog(`Sandbox proxy active — all non-admin requests forwarded to sandbox`);
+  appendLog(`Hermes Dashboard: http://localhost:${MANAGEMENT_PORT}/`);
+}
+
+function stopProxyServer(): void {
+  if (sandboxProxy) {
+    sandboxProxy.close();
+    sandboxProxy = null;
+  }
+  sandboxWsHandler = null;
+  appendLog('Sandbox proxy unmounted');
+}
+
+// ---------------------------------------------------------------------------
+// Health Probe
+// ---------------------------------------------------------------------------
+
+async function waitForHermes(remoteHost: string, accessToken: string, timeoutMs = 60000): Promise<void> {
+  const url = `https://${remoteHost}/`;
+  appendLog(`Waiting for Hermes Dashboard to be ready (max ${timeoutMs / 1000}s)... ${url}`);
+  const deadline = Date.now() + timeoutMs;
+  let attempt = 0;
+
+  while (Date.now() < deadline) {
+    attempt++;
+    try {
+      const res = await fetch(url, {
+        headers: { 'X-Access-Token': accessToken },
+        signal: AbortSignal.timeout(3000),
+      });
+      if (res.status !== 404 && !(res.status >= 500 && res.status <= 599)) {
+        appendLog(`Hermes Dashboard ready (HTTP ${res.status}), after ${attempt} probes`);
+        return;
+      }
+    } catch {
+      // Network not ready, keep retrying
+    }
+    appendLog(`  Probe #${attempt}...`);
+    await new Promise(resolve => setTimeout(resolve, 2000));
+  }
+  appendLog('Hermes Dashboard startup timeout, but still starting proxy');
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency Lock
+// ---------------------------------------------------------------------------
+
+let actionInFlight = false;
+
+// ---------------------------------------------------------------------------
+// AGS Client + Sandbox Utilities
+// ---------------------------------------------------------------------------
+
+function createAgsClient() {
+  return new AgsClient({
+    credential: {
+      secretId: process.env.TENCENTCLOUD_SECRET_ID!,
+      secretKey: process.env.TENCENTCLOUD_SECRET_KEY!,
+    },
+    region: process.env.TENCENTCLOUD_REGION || 'ap-guangzhou',
+  });
+}
+
+function getRemoteHost(instanceId: string, port: number): string {
+  const region = process.env.TENCENTCLOUD_REGION || 'ap-guangzhou';
+  return `${port}-${instanceId}.${region}.tencentags.com`;
+}
+
+async function acquireToken(instanceId: string): Promise<string> {
+  const client = createAgsClient();
+  const resp = await client.AcquireSandboxInstanceToken({ InstanceId: instanceId });
+  if (!resp.Token) throw new Error('AcquireSandboxInstanceToken did not return Token');
+  return resp.Token;
+}
+
+// ---------------------------------------------------------------------------
+// Embedded HTML
+// ---------------------------------------------------------------------------
+
+const CSS = `* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --bg: #0f1117;
+  --surface: #1a1d27;
+  --surface2: #22263a;
+  --border: #2e3250;
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --accent: #6366f1;
+  --accent-hover: #818cf8;
+  --danger: #ef4444;
+  --danger-hover: #f87171;
+  --success: #22c55e;
+  --warning: #f59e0b;
+  --radius: 8px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+/* -- Layout -- */
+.app {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-height: 100vh;
+  max-width: 1400px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 0 16px;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 20px;
+}
+
+.app-header h1 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.app-header .subtitle {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.app-body {
+  display: grid;
+  grid-template-columns: 340px 1fr;
+  grid-template-rows: auto 1fr;
+  gap: 16px;
+  padding-bottom: 24px;
+}
+
+.left-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  grid-row: 1 / 3;
+}
+
+/* -- Card -- */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+}
+
+.card-title {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 12px;
+}
+
+/* -- StatusCard -- */
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+}
+
+.status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+
+.status-idle .status-badge    { background: rgba(148,163,184,.15); border-color: rgba(148,163,184,.3); }
+.status-idle .status-dot       { background: var(--text-muted); }
+
+.status-starting .status-badge { background: rgba(245,158,11,.12); border-color: rgba(245,158,11,.4); color: #fcd34d; }
+.status-starting .status-dot   { background: var(--warning); animation: pulse 1s infinite; }
+
+.status-connecting .status-badge { background: rgba(245,158,11,.12); border-color: rgba(245,158,11,.4); color: #fcd34d; }
+.status-connecting .status-dot   { background: var(--warning); animation: pulse 1s infinite; }
+
+.status-running .status-badge  { background: rgba(34,197,94,.12); border-color: rgba(34,197,94,.4); color: #86efac; }
+.status-running .status-dot    { background: var(--success); animation: pulse 1.5s infinite; }
+
+.status-stopping .status-badge { background: rgba(239,68,68,.12); border-color: rgba(239,68,68,.4); color: #fca5a5; }
+.status-stopping .status-dot   { background: var(--danger); animation: pulse 1s infinite; }
+
+.status-pausing .status-badge  { background: rgba(245,158,11,.12); border-color: rgba(245,158,11,.4); color: #fcd34d; }
+.status-pausing .status-dot    { background: var(--warning); animation: pulse 1s infinite; }
+
+.status-paused .status-badge   { background: rgba(99,102,241,.12); border-color: rgba(99,102,241,.4); color: #a5b4fc; }
+.status-paused .status-dot     { background: var(--accent); }
+
+.status-resuming .status-badge { background: rgba(245,158,11,.12); border-color: rgba(245,158,11,.4); color: #fcd34d; }
+.status-resuming .status-dot   { background: var(--warning); animation: pulse 1s infinite; }
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.status-info {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.8rem;
+}
+
+.info-label {
+  color: var(--text-muted);
+}
+
+.info-value {
+  color: var(--text);
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 0.7rem;
+  word-break: break-all;
+  user-select: all;
+}
+
+.error-box {
+  margin-top: 10px;
+  padding: 8px 10px;
+  background: rgba(239,68,68,.1);
+  border: 1px solid rgba(239,68,68,.3);
+  border-radius: 6px;
+  font-size: 0.75rem;
+  color: #fca5a5;
+  word-break: break-all;
+}
+
+/* -- ActionPanel -- */
+.action-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 9px 16px;
+  border-radius: var(--radius);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: background 0.15s, opacity 0.15s;
+  width: 100%;
+}
+
+.btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+}
+.btn-primary:not(:disabled):hover {
+  background: var(--accent-hover);
+}
+
+.btn-danger {
+  background: var(--danger);
+  color: #fff;
+}
+.btn-danger:not(:disabled):hover {
+  background: var(--danger-hover);
+}
+
+.btn-secondary {
+  background: var(--surface2);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+.btn-secondary:not(:disabled):hover {
+  background: var(--border);
+}
+
+.connect-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 4px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.connect-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.connect-input {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 0.8rem;
+  padding: 8px 10px;
+  width: 100%;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.connect-input:focus {
+  border-color: var(--accent);
+}
+
+.connect-input::placeholder {
+  color: var(--text-muted);
+}
+
+/* -- LogPanel -- */
+.log-panel {
+  height: 260px;
+  overflow-y: auto;
+  background: var(--bg);
+  border-radius: 6px;
+  padding: 10px;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 0.72rem;
+  line-height: 1.6;
+  border: 1px solid var(--border);
+}
+
+.log-line {
+  color: #94a3b8;
+  word-break: break-all;
+}
+
+.log-line:hover {
+  color: var(--text);
+}
+
+.log-empty {
+  color: var(--text-muted);
+  font-style: italic;
+  text-align: center;
+  padding-top: 20px;
+}
+
+/* -- ConsolePanel -- */
+.console-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.console-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--accent);
+  text-decoration: none;
+  padding: 9px 16px;
+  border-radius: var(--radius);
+  border: 1px solid rgba(99,102,241,.4);
+  background: rgba(99,102,241,.08);
+  transition: background 0.15s, border-color 0.15s;
+  width: fit-content;
+}
+.console-link:hover {
+  background: rgba(99,102,241,.18);
+  border-color: rgba(99,102,241,.7);
+}
+.console-link.disabled {
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.console-placeholder {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+/* -- Scrollbar -- */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
+
+/* -- Responsive -- */
+@media (max-width: 900px) {
+  .app-body {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+  }
+  .left-panel {
+    grid-row: auto;
+  }
+}`;
+
+const HTML_BODY = `<div class="app">
+  <header class="app-header">
+    <div><h1>LocalProxy</h1><div class="subtitle">Hermes Agent Sandbox Manager</div></div>
+  </header>
+  <main class="app-body">
+    <aside class="left-panel">
+      <div id="status-card" class="card status-idle">
+        <div class="card-title">Sandbox Status</div>
+        <div class="status-badge"><span class="status-dot"></span><span id="status-text">Idle</span></div>
+        <div class="status-info">
+          <div id="row-sandboxId" class="info-row" style="display:none">
+            <span class="info-label">Sandbox ID</span>
+            <span class="info-value"></span>
+          </div>
+          <div id="row-mode" class="info-row" style="display:none">
+            <span class="info-label">Mode</span>
+            <span class="info-value"></span>
+          </div>
+          <div id="row-uptime" class="info-row" style="display:none">
+            <span class="info-label">Uptime</span>
+            <span class="info-value"></span>
+          </div>
+        </div>
+        <div id="error-box" class="error-box" style="display:none"></div>
+      </div>
+      <div id="action-panel" class="card">
+        <div class="card-title">Actions</div>
+        <div class="action-buttons">
+          <button id="btn-start"  class="btn btn-primary">Start Sandbox</button>
+          <button id="btn-stop"   class="btn btn-danger">Stop Sandbox</button>
+          <button id="btn-pause"  class="btn btn-secondary">Pause</button>
+          <button id="btn-resume" class="btn btn-secondary">Resume</button>
+        </div>
+        <div class="connect-form">
+          <span class="connect-label">Mount subpath (optional):</span>
+          <input id="subpath-input" class="connect-input" placeholder="e.g. my-project/workspace" />
+        </div>
+        <div class="connect-form">
+          <span class="connect-label">Connect to existing sandbox:</span>
+          <input id="connect-input" class="connect-input" placeholder="sandbox ID..." />
+          <button id="btn-connect" class="btn btn-secondary">Connect</button>
+        </div>
+      </div>
+    </aside>
+    <div class="right-top">
+      <div class="card">
+        <div class="card-title">Logs (<span id="log-count">0</span>)</div>
+        <div id="log-panel" class="log-panel">
+          <div class="log-empty">No logs yet...</div>
+        </div>
+      </div>
+    </div>
+    <div class="right-bottom">
+      <div class="card console-panel">
+        <div class="card-title">Hermes Dashboard</div>
+        <a id="console-link" href="/"
+           target="_blank" class="console-link disabled">Open Dashboard</a>
+        <div id="console-placeholder" class="console-placeholder">
+          Start or connect to a sandbox to access the Hermes Dashboard.
+        </div>
+      </div>
+    </div>
+  </main>
+</div>`;
+
+const CLIENT_JS = `
+// --- State cache ---
+let cachedLogs = [];
+let uptimeTimer = null;
+let startedAt = null;
+
+// --- SSE subscription ---
+const es = new EventSource('/_admin/api/events');
+es.onmessage = e => applyState(JSON.parse(e.data));
+
+// Initial fetch
+fetch('/_admin/api/status').then(r => r.json()).then(applyState);
+
+// --- DOM refs ---
+const statusCard   = document.getElementById('status-card');
+const statusText   = document.getElementById('status-text');
+const rowSandbox   = document.getElementById('row-sandboxId');
+const rowMode      = document.getElementById('row-mode');
+const rowUptime    = document.getElementById('row-uptime');
+const errorBox     = document.getElementById('error-box');
+const btnStart     = document.getElementById('btn-start');
+const btnStop      = document.getElementById('btn-stop');
+const btnPause     = document.getElementById('btn-pause');
+const btnResume    = document.getElementById('btn-resume');
+const subpathInput = document.getElementById('subpath-input');
+const connectInput = document.getElementById('connect-input');
+const btnConnect   = document.getElementById('btn-connect');
+const logPanel     = document.getElementById('log-panel');
+const logCount     = document.getElementById('log-count');
+const consoleLink  = document.getElementById('console-link');
+const consolePh    = document.getElementById('console-placeholder');
+
+const STATUS_LABELS = {
+  idle: 'Idle', starting: 'Starting', connecting: 'Connecting',
+  running: 'Running', pausing: 'Pausing', paused: 'Paused',
+  resuming: 'Resuming', stopping: 'Stopping'
+};
+
+function applyState(s) {
+  // status badge
+  statusCard.className = 'card status-' + s.status;
+  statusText.textContent = STATUS_LABELS[s.status] || s.status;
+
+  // info rows
+  showInfo(rowSandbox, s.sandboxId);
+  showInfo(rowMode,    s.mode);
+
+  // uptime timer
+  if (s.status === 'running' && s.startedAt) {
+    startedAt = s.startedAt;
+    if (!uptimeTimer) uptimeTimer = setInterval(tickUptime, 1000);
+    rowUptime.style.display = '';
+    tickUptime();
+  } else {
+    clearInterval(uptimeTimer); uptimeTimer = null; startedAt = null;
+    rowUptime.style.display = 'none';
+  }
+
+  // error box
+  if (s.error) {
+    errorBox.style.display = '';
+    errorBox.textContent = s.error;
+  } else {
+    errorBox.style.display = 'none';
+  }
+
+  // logs (incremental append)
+  if (s.logs.length !== cachedLogs.length ||
+      s.logs[s.logs.length - 1] !== cachedLogs[cachedLogs.length - 1]) {
+    const newLogs = s.logs.slice(cachedLogs.length);
+    if (cachedLogs.length === 0) logPanel.innerHTML = '';
+    newLogs.forEach(line => {
+      const d = document.createElement('div');
+      d.className = 'log-line';
+      d.textContent = line;
+      logPanel.appendChild(d);
+    });
+    cachedLogs = s.logs.slice();
+    logCount.textContent = s.logs.length;
+    if (logPanel.lastElementChild) {
+      logPanel.lastElementChild.scrollIntoView({ behavior: 'smooth' });
+    }
+  }
+
+  // buttons
+  const busy = ['starting', 'connecting', 'pausing', 'resuming', 'stopping'].includes(s.status);
+  btnStart.disabled     = s.status !== 'idle' || busy;
+  btnStop.disabled      = !['running', 'paused'].includes(s.status) || busy;
+  btnPause.disabled     = s.status !== 'running' || busy;
+  btnResume.disabled    = s.status !== 'paused'  || busy;
+  subpathInput.disabled = s.status !== 'idle' || busy;
+  connectInput.disabled = s.status !== 'idle' || busy;
+  btnConnect.disabled   = s.status !== 'idle' || busy || !connectInput.value.trim();
+
+  // console panel
+  const running = s.status === 'running';
+  const sandboxActive = ['running', 'paused'].includes(s.status);
+  consoleLink.classList.toggle('disabled', !running);
+  consolePh.style.display = sandboxActive ? 'none' : '';
+}
+
+function showInfo(row, value) {
+  if (value) {
+    row.style.display = '';
+    row.querySelector('.info-value').textContent = value;
+  } else {
+    row.style.display = 'none';
+  }
+}
+
+function tickUptime() {
+  if (!startedAt) return;
+  const secs = Math.floor((Date.now() - startedAt) / 1000);
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  const s = secs % 60;
+  const txt = h > 0 ? h + 'h ' + m + 'm ' + s + 's'
+            : m > 0 ? m + 'm ' + s + 's'
+            : s + 's';
+  rowUptime.querySelector('.info-value').textContent = txt;
+}
+
+// --- Button events ---
+btnStart.addEventListener('click', () => {
+  const subpath = subpathInput.value.trim();
+  fetch('/_admin/api/start', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ subpath: subpath || undefined }),
+  });
+});
+btnStop.addEventListener('click',   () => fetch('/_admin/api/stop',   { method: 'POST' }));
+btnPause.addEventListener('click',  () => fetch('/_admin/api/pause',  { method: 'POST' }));
+btnResume.addEventListener('click', () => fetch('/_admin/api/resume', { method: 'POST' }));
+btnConnect.addEventListener('click', doConnect);
+connectInput.addEventListener('input', () => {
+  btnConnect.disabled = !connectInput.value.trim();
+});
+connectInput.addEventListener('keydown', e => {
+  if (e.key === 'Enter' && !btnConnect.disabled) doConnect();
+});
+
+function doConnect() {
+  const id = connectInput.value.trim();
+  if (!id) return;
+  fetch('/_admin/api/connect', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sandboxId: id })
+  });
+  connectInput.value = '';
+}
+`;
+
+function getHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>LocalProxy — Hermes Agent Manager</title>
+  <style>${CSS}</style>
+</head>
+<body>
+  ${HTML_BODY}
+  <script>${CLIENT_JS}</script>
+</body>
+</html>`;
+}
+
+// ---------------------------------------------------------------------------
+// Express Application
+// ---------------------------------------------------------------------------
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// GET /_admin — Management UI
+app.get('/_admin', (_req, res) => {
+  res.setHeader('Content-Type', 'text/html');
+  res.send(getHtml());
+});
+
+// /_admin/api/* — Management API (must be registered before the catch-all proxy)
+app.get('/_admin/api/status', (_req, res) => {
+  res.json(state);
+});
+
+// GET /_admin/api/events — SSE real-time push
+app.get('/_admin/api/events', (req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.flushHeaders();
+
+  // Send current state immediately
+  res.write(`data: ${JSON.stringify(state)}\n\n`);
+
+  sseClients.add(res);
+
+  req.on('close', () => {
+    sseClients.delete(res);
+  });
+});
+
+// POST /_admin/api/start — Create new sandbox (async, progress via SSE)
+app.post('/_admin/api/start', async (req, res) => {
+  if (actionInFlight) {
+    res.status(409).json({ error: 'Action already in progress' });
+    return;
+  }
+  if (state.status !== 'idle') {
+    res.status(409).json({ error: `Current status is ${state.status}, cannot start` });
+    return;
+  }
+
+  actionInFlight = true;
+  res.json({ ok: true });
+
+  try {
+    setState({ status: 'starting', mode: 'created', sandboxId: undefined, error: undefined, logs: [] });
+    appendLog('Creating sandbox...');
+
+    const client = createAgsClient();
+    const { subpath } = req.body as { subpath?: string };
+    const mountName = process.env.MOUNT_NAME;
+    const mountOptions = mountName
+      ? [{ Name: mountName, ...(subpath ? { SubPath: subpath } : {}) }]
+      : undefined;
+    if (mountOptions) appendLog(`Mount: ${mountName}${subpath ? ` / subpath: ${subpath}` : ''}`);
+
+    const startResp = await client.StartSandboxInstance({
+      ToolName: process.env.TOOL_NAME || '',
+      Timeout: '60m',
+      ...(mountOptions ? { MountOptions: mountOptions } : {}),
+    });
+    const instanceId = startResp.Instance!.InstanceId;
+    appendLog(`Sandbox created, ID: ${instanceId}`);
+    setState({ sandboxId: instanceId, status: 'connecting' });
+
+    const accessToken = await acquireToken(instanceId);
+    const remoteHost = getRemoteHost(instanceId, HERMES_DASHBOARD_PORT);
+
+    await waitForHermes(remoteHost, accessToken);
+
+    appendLog('Starting local proxy server...');
+    startProxyServer(remoteHost, accessToken);
+
+    setState({ status: 'running', startedAt: Date.now() });
+    appendLog('Sandbox is ready!');
+
+    registerExitHandler(instanceId, 'created');
+  } catch (err: any) {
+    appendLog(`Start failed: ${err.message}`);
+    setState({ status: 'idle', error: err.message });
+  } finally {
+    actionInFlight = false;
+  }
+});
+
+// POST /_admin/api/connect — Connect to existing sandbox
+app.post('/_admin/api/connect', async (req, res) => {
+  if (actionInFlight) {
+    res.status(409).json({ error: 'Action already in progress' });
+    return;
+  }
+  if (state.status !== 'idle') {
+    res.status(409).json({ error: `Current status is ${state.status}, cannot connect` });
+    return;
+  }
+
+  const { sandboxId } = req.body as { sandboxId?: string };
+  if (!sandboxId) {
+    res.status(400).json({ error: 'Missing sandboxId' });
+    return;
+  }
+
+  actionInFlight = true;
+  res.json({ ok: true });
+
+  try {
+    setState({ status: 'connecting', mode: 'connected', sandboxId, error: undefined, logs: [] });
+    appendLog(`Connecting to sandbox ${sandboxId}...`);
+
+    const accessToken = await acquireToken(sandboxId);
+    appendLog(`Token acquired, sandbox ID: ${sandboxId}`);
+
+    const remoteHost = getRemoteHost(sandboxId, HERMES_DASHBOARD_PORT);
+
+    await waitForHermes(remoteHost, accessToken);
+
+    appendLog('Starting local proxy server...');
+    startProxyServer(remoteHost, accessToken);
+
+    setState({ status: 'running', startedAt: Date.now() });
+    appendLog('Connected and ready!');
+
+    registerExitHandler(sandboxId, 'connected');
+  } catch (err: any) {
+    appendLog(`Connect failed: ${err.message}`);
+    setState({ status: 'idle', error: err.message });
+  } finally {
+    actionInFlight = false;
+  }
+});
+
+// POST /_admin/api/stop — Stop/destroy sandbox
+app.post('/_admin/api/stop', async (_req, res) => {
+  if (actionInFlight) {
+    res.status(409).json({ error: 'Action already in progress' });
+    return;
+  }
+  if (!['running', 'paused'].includes(state.status)) {
+    res.status(409).json({ error: `Current status is ${state.status}, cannot stop` });
+    return;
+  }
+
+  actionInFlight = true;
+  res.json({ ok: true });
+
+  await performStop();
+  actionInFlight = false;
+});
+
+// POST /_admin/api/pause — Pause sandbox
+app.post('/_admin/api/pause', async (_req, res) => {
+  if (actionInFlight) {
+    res.status(409).json({ error: 'Action already in progress' });
+    return;
+  }
+  if (state.status !== 'running') {
+    res.status(409).json({ error: `Current status is ${state.status}, cannot pause` });
+    return;
+  }
+
+  actionInFlight = true;
+  res.json({ ok: true });
+
+  try {
+    setState({ status: 'pausing' });
+    appendLog('Pausing sandbox...');
+
+    stopProxyServer();
+
+    const client = createAgsClient();
+    await client.PauseSandboxInstance({ InstanceId: state.sandboxId! });
+    appendLog('Sandbox paused');
+
+    setState({ status: 'paused', startedAt: undefined });
+  } catch (err: any) {
+    appendLog(`Pause failed: ${err.message}`);
+    // Rollback: re-acquire token and restart proxy
+    try {
+      const accessToken = await acquireToken(state.sandboxId!);
+      const remoteHost = getRemoteHost(state.sandboxId!, HERMES_DASHBOARD_PORT);
+      startProxyServer(remoteHost, accessToken);
+    } catch { /* ignore */ }
+    setState({ status: 'running', error: err.message });
+  } finally {
+    actionInFlight = false;
+  }
+});
+
+// POST /_admin/api/resume — Resume paused sandbox
+app.post('/_admin/api/resume', async (_req, res) => {
+  if (actionInFlight) {
+    res.status(409).json({ error: 'Action already in progress' });
+    return;
+  }
+  if (state.status !== 'paused') {
+    res.status(409).json({ error: `Current status is ${state.status}, cannot resume` });
+    return;
+  }
+  if (!state.sandboxId) {
+    res.status(409).json({ error: 'Missing sandboxId, cannot resume' });
+    return;
+  }
+
+  actionInFlight = true;
+  res.json({ ok: true });
+
+  try {
+    setState({ status: 'resuming' });
+    appendLog('Resuming sandbox...');
+
+    const client = createAgsClient();
+    await client.ResumeSandboxInstance({ InstanceId: state.sandboxId! });
+    appendLog(`Resume command sent`);
+
+    const accessToken = await acquireToken(state.sandboxId!);
+    const remoteHost = getRemoteHost(state.sandboxId!, HERMES_DASHBOARD_PORT);
+
+    await waitForHermes(remoteHost, accessToken);
+
+    startProxyServer(remoteHost, accessToken);
+    setState({ status: 'running', startedAt: Date.now() });
+    appendLog('Sandbox is ready!');
+  } catch (err: any) {
+    appendLog(`Resume failed: ${err.message}`);
+    setState({ status: 'paused', error: err.message });
+  } finally {
+    actionInFlight = false;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Stop Logic
+// ---------------------------------------------------------------------------
+
+let currentInstanceId: string | null = null;
+let currentMode: SandboxMode | null = null;
+let exitHandlerRegistered = false;
+
+function registerExitHandler(instanceId: string, mode: SandboxMode) {
+  currentInstanceId = instanceId;
+  currentMode = mode;
+
+  if (exitHandlerRegistered) return;
+  exitHandlerRegistered = true;
+
+  const cleanup = async () => {
+    console.log('\n\nShutting down...');
+    await performStop();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', cleanup);
+  process.on('SIGTERM', cleanup);
+}
+
+async function performStop(): Promise<void> {
+  setState({ status: 'stopping' });
+  appendLog('Stopping...');
+
+  stopProxyServer();
+  appendLog('Proxy server closed');
+
+  if (currentInstanceId && currentMode === 'created') {
+    try {
+      const client = createAgsClient();
+      await client.StopSandboxInstance({ InstanceId: currentInstanceId });
+      appendLog('Sandbox stopped');
+    } catch (err: any) {
+      appendLog(`Failed to stop sandbox: ${err.message}`);
+    }
+  } else if (currentMode === 'connected') {
+    appendLog(`Sandbox ${state.sandboxId} is still running (connect mode does not stop it)`);
+  }
+
+  currentInstanceId = null;
+  currentMode = null;
+
+  setState({
+    status: 'idle',
+    mode: undefined,
+    sandboxId: undefined,
+    startedAt: undefined,
+    error: undefined,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Catch-all: proxy everything else to sandbox (Hermes Dashboard serves at /)
+// This must be registered AFTER all /_admin routes.
+// ---------------------------------------------------------------------------
+
+app.use('/', (req, res) => {
+  if (!sandboxProxy) {
+    // Sandbox not running — redirect to management UI
+    res.redirect('/_admin');
+    return;
+  }
+  sandboxProxy.web(req, res);
+});
+
+// ---------------------------------------------------------------------------
+// Start Management Server
+// ---------------------------------------------------------------------------
+
+const server = app.listen(MANAGEMENT_PORT, () => {
+  console.log(`\nLocalProxy management server started`);
+  console.log(`   Management UI: http://localhost:${MANAGEMENT_PORT}/_admin`);
+  console.log(`   API:           http://localhost:${MANAGEMENT_PORT}/_admin/api`);
+  console.log('   Press Ctrl+C to exit\n');
+});
+
+server.on('upgrade', (req, socket, head) => {
+  if (sandboxWsHandler) sandboxWsHandler(req, socket, head);
+});


### PR DESCRIPTION
## Summary

- Add a complete cookbook example for deploying [NousResearch Hermes Agent](https://github.com/NousResearch/hermes-agent) on Tencent Cloud AGS with CFS persistent storage
- Includes Dockerfile, LocalProxy management UI, one-command sandbox tool creation, and bilingual documentation (EN/ZH)
- Follows the same structure as `openclaw-cookbook` but adapted for Hermes (CFS instead of COS, root-path Dashboard proxy, environment-based configuration)

## What's Included

| Component | Description |
|-----------|-------------|
| `Dockerfile` | Minimal layer on official `nousresearch/hermes-agent` image + AGS envd |
| `localproxy/server.ts` | Express management UI + reverse proxy serving Dashboard at `/` |
| `localproxy/create-tool.ts` | One-command AGS sandbox tool creation with ports, env vars, CFS mount |
| `Makefile` | Unified workflow loading config from single `.env` file |
| `README.md` / `README_zh.md` | Full setup guide (build → create tool → run) |

## Key Design Decisions

- **CFS over COS**: CFS is POSIX-compatible, supports SQLite WAL locking natively — no workarounds needed
- **Root-path proxy**: Hermes Dashboard serves at `/`, so localproxy uses `/_admin` for management UI and proxies everything else to the sandbox
- **Single `.env` file**: All configuration (Makefile + localproxy) reads from one `localproxy/.env`
- **Environment variables via SDK**: All required env vars (`HERMES_HOME`, `GATEWAY_ALLOW_ALL_USERS`, etc.) are set programmatically in `create-tool.ts`

## Test Plan

- [x] `make push` builds and pushes image successfully
- [x] `make create_sandbox_tool` creates AGS tool with correct ports/env/CFS config
- [x] `make run` starts localproxy, sandbox boots, Dashboard accessible at `localhost:3001/`
- [x] No credential leaks in committed files
- [x] Both READMEs reviewed for accuracy and consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)