### PR TITLE
feat(utils): add sandbox monitoring query docs and examples

### DIFF
--- a/utils/sandbox-monitor/README.md
+++ b/utils/sandbox-monitor/README.md
@@ -1,0 +1,530 @@
+# 沙箱监控查询指南
+
+本文档说明客户如何通过腾讯云云监控标准接口查询 AGS 沙箱实例的运行监控指标。
+
+## 概述
+
+### 职责边界
+
+| 角色 | 职责 |
+|---|---|
+| 平台侧 | 负责沙箱指标的采集、上报、存储和接入云监控 |
+| 客户侧 | 使用腾讯云云监控 `GetMonitorData` 接口查询指标 |
+
+### 基本信息
+
+| 项 | 值 |
+|---|---|
+| 云 API | `GetMonitorData` |
+| API 版本 | `2018-07-24` |
+| API 域名 | `monitor.tencentcloudapi.com` |
+| Namespace | `QCE/AGS` |
+| 推荐 SDK | 腾讯云官方 Python / Go SDK |
+| 认证方式 | 腾讯云 SecretId / SecretKey (TC3-HMAC-SHA256 签名) |
+| 官方文档 | [GetMonitorData API](https://cloud.tencent.com/document/api/248/31014) |
+
+---
+
+## 查询参数
+
+### 地域 (Region)
+
+监控数据按地域存储，查询时必须指定沙箱实际运行地域。
+
+| 地域 | Region 值 |
+|---|---|
+| 北京 | `ap-beijing` |
+| 上海 | `ap-shanghai` |
+| 广州 | `ap-guangzhou` |
+| 新加坡 | `ap-singapore` |
+| 美东（弗吉尼亚） | `na-ashburn` |
+
+### 查询维度 (Dimensions)
+
+| 维度名 | 必填 | 示例 | 说明 |
+|---|:---:|---|---|
+| `tool_id` | 是 | `sdt-ggdjgpcl` | 沙箱工具 ID |
+| `instance_id` | 是 | `3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs` | 沙箱实例 ID |
+
+`Dimensions` 标准 JSON 格式：
+
+```json
+[
+  {"Name": "tool_id", "Value": "sdt-ggdjgpcl"},
+  {"Name": "instance_id", "Value": "3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs"}
+]
+```
+
+---
+
+## 监控指标列表
+
+`GetMonitorData` 单次请求只支持一个 `MetricName`。如需查询全部指标，需逐个调用。
+
+| MetricName | 单位 | 说明 |
+|---|---|---|
+| `SandboxCpuUsagePercent` | `%` | CPU 使用率（多核场景可超 100%，如 2 核满载约 200%） |
+| `SandboxCpuUsedCores` | `cores` | CPU 已使用核数 |
+| `SandboxMemoryUsagePercent` | `%` | 内存使用率 |
+| `SandboxMemoryUsedBytes` | `Bytes` | 内存已使用字节数 |
+| `SandboxDiskReadBytesPerSecond` | `Bytes/s` | 磁盘读速率 |
+| `SandboxDiskWriteBytesPerSecond` | `Bytes/s` | 磁盘写速率 |
+| `SandboxFsUsagePercent` | `%` | 文件系统使用率 |
+| `SandboxFsUsedBytes` | `Bytes` | 文件系统已使用字节数 |
+| `SandboxNetworkRxBytesPerSecond` | `Bytes/s` | 网络入方向速率 |
+| `SandboxNetworkTxBytesPerSecond` | `Bytes/s` | 网络出方向速率 |
+
+---
+
+## 接口说明
+
+### 请求方式
+
+- **协议**：HTTPS
+- **方法**：POST
+- **域名**：`monitor.tencentcloudapi.com`
+- **认证**：TC3-HMAC-SHA256 签名（由 SDK 自动处理）
+
+### 请求体 (Request Body)
+
+```json
+{
+  "Namespace": "QCE/AGS",
+  "MetricName": "SandboxCpuUsagePercent",
+  "Instances": [
+    {
+      "Dimensions": [
+        {"Name": "tool_id", "Value": "sdt-ggdjgpcl"},
+        {"Name": "instance_id", "Value": "3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs"}
+      ]
+    }
+  ],
+  "Period": 60,
+  "StartTime": "2026-05-19T14:00:00+08:00",
+  "EndTime": "2026-05-19T15:00:00+08:00"
+}
+```
+
+### 请求字段说明
+
+| 字段 | 必填 | 类型 | 说明 |
+|---|:---:|---|---|
+| `Namespace` | 是 | String | 固定为 `QCE/AGS` |
+| `MetricName` | 是 | String | 指标名，见上方指标列表 |
+| `Instances` | 是 | Array | 查询对象数组，单次最多 50 个实例 |
+| `Instances[].Dimensions` | 是 | Array | 只传 `tool_id` 和 `instance_id` |
+| `Period` | 否 | Integer | 统计周期，单位秒，建议 `60` |
+| `StartTime` | 否 | String | ISO 8601 时间，必须带时区（如 `+08:00`） |
+| `EndTime` | 否 | String | ISO 8601 时间，必须带时区 |
+
+### 响应体 - 成功且有数据
+
+```json
+{
+  "Response": {
+    "Period": 60,
+    "MetricName": "SandboxCpuUsagePercent",
+    "DataPoints": [
+      {
+        "Dimensions": [
+          {"Name": "instance_id", "Value": "3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs"},
+          {"Name": "tool_id", "Value": "sdt-ggdjgpcl"}
+        ],
+        "Timestamps": [1747634400, 1747634460, 1747634520],
+        "Values": [0.12, 0.08, 0.15]
+      }
+    ],
+    "StartTime": "2026-05-19T14:00:00+08:00",
+    "EndTime": "2026-05-19T15:00:00+08:00",
+    "Msg": "Success",
+    "RequestId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  }
+}
+```
+
+### 响应体 - 成功但无数据
+
+```json
+{
+  "Response": {
+    "Period": 60,
+    "MetricName": "SandboxCpuUsagePercent",
+    "DataPoints": [
+      {
+        "Dimensions": [
+          {"Name": "instance_id", "Value": "3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs"},
+          {"Name": "tool_id", "Value": "sdt-ggdjgpcl"}
+        ],
+        "Timestamps": [],
+        "Values": []
+      }
+    ],
+    "Msg": "Success",
+    "RequestId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  }
+}
+```
+
+> 无数据常见原因：沙箱未运行、地域不匹配、时间窗口不对、数据刚产生尚未完成索引（建议等待 1-3 分钟）。
+
+### 响应体 - 错误
+
+```json
+{
+  "Response": {
+    "Error": {
+      "Code": "InvalidParameterValue",
+      "Message": "invalid MetricName: InvalidMetric"
+    },
+    "RequestId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  }
+}
+```
+
+常见错误码：
+
+| 错误码 | 说明 | 排查建议 |
+|---|---|---|
+| `InvalidParameterValue` | 参数取值错误 | 检查 Namespace、MetricName、Dimensions、Region |
+| `LimitExceeded.LimitedAccess` | 请求受限/限频 | 降低并发，拆分时间窗口 |
+| `FailedOperation.ErrNotOpen` | 服务未开通 | 检查账号服务状态 |
+| `FailedOperation.ErrOwed` | 欠费 | 检查账号费用状态 |
+| `InternalError` | 内部错误 | 稍后重试，保留 RequestId |
+
+---
+
+## Python SDK 使用
+
+> **环境要求**：Python >= 3.10
+
+### 安装依赖
+
+```bash
+pip install tencentcloud-sdk-python-common tencentcloud-sdk-python-monitor
+```
+
+### 设置环境变量
+
+```bash
+export TENCENTCLOUD_SECRET_ID="<你的 SecretId>"
+export TENCENTCLOUD_SECRET_KEY="<你的 SecretKey>"
+```
+
+### 完整示例
+
+```python
+import json
+import os
+from datetime import datetime, timedelta
+
+from tencentcloud.common import credential
+from tencentcloud.common.exception.tencent_cloud_sdk_exception import TencentCloudSDKException
+from tencentcloud.common.profile.client_profile import ClientProfile
+from tencentcloud.common.profile.http_profile import HttpProfile
+from tencentcloud.monitor.v20180724 import monitor_client, models
+
+
+def query_sandbox_metric(
+    region: str,
+    tool_id: str,
+    instance_id: str,
+    metric_name: str,
+    start_time: str = None,
+    end_time: str = None,
+    period: int = 60,
+) -> dict:
+    """
+    查询沙箱监控指标。
+
+    Args:
+        region: 地域，如 "ap-guangzhou"
+        tool_id: 沙箱工具 ID，如 "sdt-ggdjgpcl"
+        instance_id: 沙箱实例 ID
+        metric_name: 指标名，如 "SandboxCpuUsagePercent"
+        start_time: 开始时间 (ISO 8601)，默认 1 小时前
+        end_time: 结束时间 (ISO 8601)，默认当前时间
+        period: 统计周期，单位秒，默认 60
+
+    Returns:
+        GetMonitorData 响应字典
+    """
+    # 构造凭证
+    cred = credential.Credential(
+        os.environ["TENCENTCLOUD_SECRET_ID"],
+        os.environ["TENCENTCLOUD_SECRET_KEY"],
+    )
+
+    # 配置客户端
+    http_profile = HttpProfile()
+    http_profile.endpoint = "monitor.tencentcloudapi.com"
+    http_profile.reqMethod = "POST"
+
+    client_profile = ClientProfile()
+    client_profile.signMethod = "TC3-HMAC-SHA256"
+    client_profile.httpProfile = http_profile
+
+    client = monitor_client.MonitorClient(cred, region, client_profile)
+
+    # 默认时间范围：最近 1 小时
+    now = datetime.now().astimezone()
+    if not end_time:
+        end_time = now.strftime("%Y-%m-%dT%H:%M:%S%z")
+        end_time = end_time[:-2] + ":" + end_time[-2:]
+    if not start_time:
+        start = now - timedelta(hours=1)
+        start_time = start.strftime("%Y-%m-%dT%H:%M:%S%z")
+        start_time = start_time[:-2] + ":" + start_time[-2:]
+
+    # 构造请求
+    payload = {
+        "Namespace": "QCE/AGS",
+        "MetricName": metric_name,
+        "Instances": [
+            {
+                "Dimensions": [
+                    {"Name": "tool_id", "Value": tool_id},
+                    {"Name": "instance_id", "Value": instance_id},
+                ]
+            }
+        ],
+        "Period": period,
+        "StartTime": start_time,
+        "EndTime": end_time,
+    }
+
+    req = models.GetMonitorDataRequest()
+    req.from_json_string(json.dumps(payload))
+
+    resp = client.GetMonitorData(req)
+    return json.loads(resp.to_json_string())
+
+
+# 使用示例
+if __name__ == "__main__":
+    try:
+        result = query_sandbox_metric(
+            region="ap-guangzhou",
+            tool_id="sdt-ggdjgpcl",
+            instance_id="3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs",
+            metric_name="SandboxCpuUsagePercent",
+        )
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    except TencentCloudSDKException as e:
+        print(f"查询失败: {e}")
+```
+
+### 批量查询所有指标
+
+```python
+ALL_METRICS = [
+    "SandboxCpuUsagePercent",
+    "SandboxCpuUsedCores",
+    "SandboxMemoryUsagePercent",
+    "SandboxMemoryUsedBytes",
+    "SandboxDiskReadBytesPerSecond",
+    "SandboxDiskWriteBytesPerSecond",
+    "SandboxFsUsagePercent",
+    "SandboxFsUsedBytes",
+    "SandboxNetworkRxBytesPerSecond",
+    "SandboxNetworkTxBytesPerSecond",
+]
+
+import time
+
+for metric in ALL_METRICS:
+    result = query_sandbox_metric(
+        region="ap-guangzhou",
+        tool_id="sdt-ggdjgpcl",
+        instance_id="3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs",
+        metric_name=metric,
+    )
+    data_points = result.get("DataPoints", [])
+    if data_points and data_points[0].get("Values"):
+        values = data_points[0]["Values"]
+        print(f"{metric}: avg={sum(values)/len(values):.4f}, max={max(values):.4f}, count={len(values)}")
+    else:
+        print(f"{metric}: no data")
+    time.sleep(0.1)  # 避免触发频率限制
+```
+
+---
+
+## Golang SDK 使用
+
+### 安装依赖
+
+```bash
+go get -u github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
+go get -u github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor
+```
+
+### 设置环境变量
+
+```bash
+export TENCENTCLOUD_SECRET_ID="<你的 SecretId>"
+export TENCENTCLOUD_SECRET_KEY="<你的 SecretKey>"
+```
+
+### 完整示例
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
+	sdkErrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile"
+	monitor "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor/v20180724"
+)
+
+func querySandboxMetric(region, toolID, instanceID, metricName string) (string, error) {
+	// 构造凭证
+	cred := common.NewCredential(
+		os.Getenv("TENCENTCLOUD_SECRET_ID"),
+		os.Getenv("TENCENTCLOUD_SECRET_KEY"),
+	)
+
+	// 配置客户端
+	cpf := profile.NewClientProfile()
+	cpf.SignMethod = "TC3-HMAC-SHA256"
+	cpf.HttpProfile.Endpoint = "monitor.tencentcloudapi.com"
+	cpf.HttpProfile.ReqMethod = "POST"
+
+	client, err := monitor.NewClient(cred, region, cpf)
+	if err != nil {
+		return "", fmt.Errorf("创建客户端失败: %w", err)
+	}
+
+	// 构造请求
+	now := time.Now()
+	start := now.Add(-1 * time.Hour)
+
+	req := monitor.NewGetMonitorDataRequest()
+	req.Namespace = common.StringPtr("QCE/AGS")
+	req.MetricName = common.StringPtr(metricName)
+	req.Period = common.Uint64Ptr(60)
+	req.StartTime = common.StringPtr(start.Format("2006-01-02T15:04:05-07:00"))
+	req.EndTime = common.StringPtr(now.Format("2006-01-02T15:04:05-07:00"))
+	req.Instances = []*monitor.Instance{
+		{
+			Dimensions: []*monitor.Dimension{
+				{
+					Name:  common.StringPtr("tool_id"),
+					Value: common.StringPtr(toolID),
+				},
+				{
+					Name:  common.StringPtr("instance_id"),
+					Value: common.StringPtr(instanceID),
+				},
+			},
+		},
+	}
+
+	// 发送请求
+	resp, err := client.GetMonitorData(req)
+	if _, ok := err.(*sdkErrors.TencentCloudSDKError); ok {
+		return "", fmt.Errorf("API 错误: %w", err)
+	}
+	if err != nil {
+		return "", fmt.Errorf("请求失败: %w", err)
+	}
+
+	return resp.ToJsonString(), nil
+}
+
+func main() {
+	region := "ap-guangzhou"
+	toolID := "sdt-ggdjgpcl"
+	instanceID := "3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs"
+	metricName := "SandboxCpuUsagePercent"
+
+	result, err := querySandboxMetric(region, toolID, instanceID, metricName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "查询失败: %v\n", err)
+		os.Exit(1)
+	}
+
+	// 格式化输出
+	var prettyJSON map[string]interface{}
+	json.Unmarshal([]byte(result), &prettyJSON)
+	output, _ := json.MarshalIndent(prettyJSON, "", "  ")
+	fmt.Println(string(output))
+}
+```
+
+### 批量查询所有指标
+
+在上述 `main.go` 中添加以下代码即可批量查询：
+
+```go
+// 全部沙箱监控指标
+var allMetrics = []string{
+	"SandboxCpuUsagePercent",
+	"SandboxCpuUsedCores",
+	"SandboxMemoryUsagePercent",
+	"SandboxMemoryUsedBytes",
+	"SandboxDiskReadBytesPerSecond",
+	"SandboxDiskWriteBytesPerSecond",
+	"SandboxFsUsagePercent",
+	"SandboxFsUsedBytes",
+	"SandboxNetworkRxBytesPerSecond",
+	"SandboxNetworkTxBytesPerSecond",
+}
+
+func queryAllMetrics(region, toolID, instanceID string) {
+	for _, metric := range allMetrics {
+		result, err := querySandboxMetric(region, toolID, instanceID, metric)
+		if err != nil {
+			fmt.Printf("[%s] 查询失败: %v\n", metric, err)
+		} else {
+			fmt.Printf("[%s] %s\n", metric, result)
+		}
+		time.Sleep(100 * time.Millisecond) // 避免触发频率限制
+	}
+}
+```
+
+---
+
+## 调用限制与建议
+
+| 限制项 | 说明 |
+|---|---|
+| MetricName | 单次请求只能查询一个指标 |
+| Instances | 单次最多查询 50 个实例 |
+| 数据点上限 | 单次请求最多返回 7200 个数据点 |
+| QPS | 默认有频率限制，批量查询需控制并发 |
+| 数据延迟 | 新产生的数据可能有 1-3 分钟延迟 |
+
+---
+
+## 安全建议
+
+- **不要** 将 `SecretId` / `SecretKey` 写入代码仓库、文档或日志
+- **推荐** 使用环境变量或密钥管理服务存储凭证
+- **建议** 只授予云监控查询所需的最小权限
+- 排查问题时提供 `RequestId`，不要暴露明文密钥
+
+---
+
+## 目录结构
+
+```
+sandbox-monitor/
+├── README.md                          # 本文档
+├── examples/
+│   ├── python/
+│   │   ├── query_single_metric.py     # Python 查询单个指标示例
+│   │   ├── query_all_metrics.py       # Python 查询所有指标示例
+│   │   └── requirements.txt           # Python 依赖
+│   └── golang/
+│       ├── main.go                    # Go 查询示例
+│       └── go.mod                     # Go 模块定义
+└── skill/
+    └── sandbox-monitor.md             # Claude Code skill 文件
+```

--- a/utils/sandbox-monitor/examples/golang/go.mod
+++ b/utils/sandbox-monitor/examples/golang/go.mod
@@ -1,0 +1,7 @@
+module sandbox-monitor-example
+
+go 1.21
+
+require github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor v1.0.940
+
+require github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.940

--- a/utils/sandbox-monitor/examples/golang/go.sum
+++ b/utils/sandbox-monitor/examples/golang/go.sum
@@ -1,0 +1,4 @@
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.940 h1:uqhura99NprOzYt483VeS5oNBMih5h7VPVnyyPYElw0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.940/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor v1.0.940 h1:qNKHa5P6mb+Hw0mm6O2pqTU0B3EeGsS4uxjrGAnzSxA=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor v1.0.940/go.mod h1:YIpAiEKWKl9K1GjSlAPxGUKyXCy/P7aPJlg2fqi+7Zg=

--- a/utils/sandbox-monitor/examples/golang/main.go
+++ b/utils/sandbox-monitor/examples/golang/main.go
@@ -1,0 +1,141 @@
+// 沙箱监控查询示例 - 使用腾讯云 Go SDK 查询 AGS 沙箱监控指标
+//
+// 使用前请设置环境变量：
+//   export TENCENTCLOUD_SECRET_ID="<你的 SecretId>"
+//   export TENCENTCLOUD_SECRET_KEY="<你的 SecretKey>"
+//
+// 运行：
+//   go run main.go --region ap-guangzhou --tool-id sdt-0h5n0fil --instance-id xxx
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
+	sdkErrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile"
+	monitor "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor/v20180724"
+)
+
+// 全部沙箱监控指标
+var allMetrics = []string{
+	"SandboxCpuUsagePercent",
+	"SandboxCpuUsedCores",
+	"SandboxMemoryUsagePercent",
+	"SandboxMemoryUsedBytes",
+	"SandboxDiskReadBytesPerSecond",
+	"SandboxDiskWriteBytesPerSecond",
+	"SandboxFsUsagePercent",
+	"SandboxFsUsedBytes",
+	"SandboxNetworkRxBytesPerSecond",
+	"SandboxNetworkTxBytesPerSecond",
+}
+
+func createClient(region string) (*monitor.Client, error) {
+	cred := common.NewCredential(
+		os.Getenv("TENCENTCLOUD_SECRET_ID"),
+		os.Getenv("TENCENTCLOUD_SECRET_KEY"),
+	)
+
+	cpf := profile.NewClientProfile()
+	cpf.SignMethod = "TC3-HMAC-SHA256"
+	cpf.HttpProfile.Endpoint = "monitor.tencentcloudapi.com"
+	cpf.HttpProfile.ReqMethod = "POST"
+
+	return monitor.NewClient(cred, region, cpf)
+}
+
+func querySandboxMetric(client *monitor.Client, toolID, instanceID, metricName, startTime, endTime string) (string, error) {
+	req := monitor.NewGetMonitorDataRequest()
+	req.Namespace = common.StringPtr("QCE/AGS")
+	req.MetricName = common.StringPtr(metricName)
+	req.Period = common.Uint64Ptr(60)
+	req.StartTime = common.StringPtr(startTime)
+	req.EndTime = common.StringPtr(endTime)
+	req.Instances = []*monitor.Instance{
+		{
+			Dimensions: []*monitor.Dimension{
+				{
+					Name:  common.StringPtr("tool_id"),
+					Value: common.StringPtr(toolID),
+				},
+				{
+					Name:  common.StringPtr("instance_id"),
+					Value: common.StringPtr(instanceID),
+				},
+			},
+		},
+	}
+
+	resp, err := client.GetMonitorData(req)
+	if _, ok := err.(*sdkErrors.TencentCloudSDKError); ok {
+		return "", fmt.Errorf("API 错误: %w", err)
+	}
+	if err != nil {
+		return "", fmt.Errorf("请求失败: %w", err)
+	}
+
+	return resp.ToJsonString(), nil
+}
+
+func main() {
+	region := flag.String("region", "ap-guangzhou", "地域")
+	toolID := flag.String("tool-id", "", "沙箱工具 ID (必填)")
+	instanceID := flag.String("instance-id", "", "沙箱实例 ID (必填)")
+	metric := flag.String("metric", "SandboxCpuUsagePercent", "指标名，传 all 查询全部")
+	flag.Parse()
+
+	if *toolID == "" || *instanceID == "" {
+		fmt.Fprintf(os.Stderr, "错误: --tool-id 和 --instance-id 为必填参数\n")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	now := time.Now()
+	start := now.Add(-1 * time.Hour)
+	startTime := start.Format("2006-01-02T15:04:05-07:00")
+	endTime := now.Format("2006-01-02T15:04:05-07:00")
+
+	fmt.Printf("查询参数:\n")
+	fmt.Printf("  Region:      %s\n", *region)
+	fmt.Printf("  Tool ID:     %s\n", *toolID)
+	fmt.Printf("  Instance ID: %s\n", *instanceID)
+	fmt.Printf("  Metric:      %s\n", *metric)
+	fmt.Printf("  时间范围:    %s ~ %s\n", startTime, endTime)
+	fmt.Println("======================================================================")
+
+	client, err := createClient(*region)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "创建客户端失败: %v\n", err)
+		os.Exit(1)
+	}
+
+	var metrics []string
+	if strings.ToLower(*metric) == "all" {
+		metrics = allMetrics
+	} else {
+		metrics = []string{*metric}
+	}
+
+	for _, m := range metrics {
+		result, err := querySandboxMetric(client, *toolID, *instanceID, m, startTime, endTime)
+		if err != nil {
+			fmt.Printf("[%s] 查询失败: %v\n", m, err)
+		} else {
+			var resp map[string]interface{}
+			if jsonErr := json.Unmarshal([]byte(result), &resp); jsonErr != nil {
+				fmt.Printf("[%s] JSON 解析失败: %v\n", m, jsonErr)
+				continue
+			}
+			output, _ := json.MarshalIndent(resp, "", "  ")
+			fmt.Printf("[%s] %s\n", m, string(output))
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/utils/sandbox-monitor/examples/python/query_all_metrics.py
+++ b/utils/sandbox-monitor/examples/python/query_all_metrics.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+批量查询沙箱全部 10 个监控指标示例。
+
+使用前请设置环境变量：
+    export TENCENTCLOUD_SECRET_ID="<你的 SecretId>"
+    export TENCENTCLOUD_SECRET_KEY="<你的 SecretKey>"
+
+使用方式：
+    python query_all_metrics.py --region ap-guangzhou --tool-id sdt-xxx --instance-id xxx
+"""
+import argparse
+import json
+import os
+import time
+from datetime import datetime, timedelta
+
+from tencentcloud.common import credential
+from tencentcloud.common.exception.tencent_cloud_sdk_exception import TencentCloudSDKException
+from tencentcloud.common.profile.client_profile import ClientProfile
+from tencentcloud.common.profile.http_profile import HttpProfile
+from tencentcloud.monitor.v20180724 import monitor_client, models
+
+
+ALL_METRICS = [
+    "SandboxCpuUsagePercent",
+    "SandboxCpuUsedCores",
+    "SandboxMemoryUsagePercent",
+    "SandboxMemoryUsedBytes",
+    "SandboxDiskReadBytesPerSecond",
+    "SandboxDiskWriteBytesPerSecond",
+    "SandboxFsUsagePercent",
+    "SandboxFsUsedBytes",
+    "SandboxNetworkRxBytesPerSecond",
+    "SandboxNetworkTxBytesPerSecond",
+]
+
+
+def create_monitor_client(region: str) -> monitor_client.MonitorClient:
+    """创建云监控客户端。"""
+    cred = credential.Credential(
+        os.environ["TENCENTCLOUD_SECRET_ID"],
+        os.environ["TENCENTCLOUD_SECRET_KEY"],
+    )
+
+    http_profile = HttpProfile()
+    http_profile.endpoint = "monitor.tencentcloudapi.com"
+    http_profile.reqMethod = "POST"
+
+    client_profile = ClientProfile()
+    client_profile.signMethod = "TC3-HMAC-SHA256"
+    client_profile.httpProfile = http_profile
+
+    return monitor_client.MonitorClient(cred, region, client_profile)
+
+
+def query_metric(
+    client: monitor_client.MonitorClient,
+    tool_id: str,
+    instance_id: str,
+    metric_name: str,
+    start_time: str,
+    end_time: str,
+    period: int = 60,
+) -> dict:
+    """查询单个指标。"""
+    payload = {
+        "Namespace": "QCE/AGS",
+        "MetricName": metric_name,
+        "Instances": [
+            {
+                "Dimensions": [
+                    {"Name": "tool_id", "Value": tool_id},
+                    {"Name": "instance_id", "Value": instance_id},
+                ]
+            }
+        ],
+        "Period": period,
+        "StartTime": start_time,
+        "EndTime": end_time,
+    }
+
+    req = models.GetMonitorDataRequest()
+    req.from_json_string(json.dumps(payload))
+    resp = client.GetMonitorData(req)
+    return json.loads(resp.to_json_string())
+
+
+def format_iso_time(dt: datetime) -> str:
+    """格式化为带时区的 ISO 8601 字符串。"""
+    s = dt.strftime("%Y-%m-%dT%H:%M:%S%z")
+    return s[:-2] + ":" + s[-2:]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="批量查询沙箱全部监控指标")
+    parser.add_argument("--region", required=True, help="地域，如 ap-guangzhou")
+    parser.add_argument("--tool-id", required=True, help="沙箱工具 ID，如 sdt-0h5n0fil")
+    parser.add_argument("--instance-id", required=True, help="沙箱实例 ID")
+    args = parser.parse_args()
+
+    REGION = args.region
+    TOOL_ID = args.tool_id
+    INSTANCE_ID = args.instance_id
+
+    now = datetime.now().astimezone()
+    start = now - timedelta(hours=1)
+    start_time = format_iso_time(start)
+    end_time = format_iso_time(now)
+
+    print(f"查询参数:")
+    print(f"  Region:      {REGION}")
+    print(f"  Tool ID:     {TOOL_ID}")
+    print(f"  Instance ID: {INSTANCE_ID}")
+    print(f"  时间范围:    {start_time} ~ {end_time}")
+    print(f"  统计周期:    60s")
+    print("=" * 70)
+
+    client = create_monitor_client(REGION)
+
+    for metric in ALL_METRICS:
+        try:
+            result = query_metric(
+                client=client,
+                tool_id=TOOL_ID,
+                instance_id=INSTANCE_ID,
+                metric_name=metric,
+                start_time=start_time,
+                end_time=end_time,
+            )
+
+            data_points = result.get("DataPoints", [])
+            if data_points and data_points[0].get("Values"):
+                values = data_points[0]["Values"]
+                avg = sum(values) / len(values)
+                mx = max(values)
+                print(f"[{metric}] count={len(values)}, avg={avg:.4f}, max={mx:.4f}")
+            else:
+                print(f"[{metric}] 无数据")
+
+        except TencentCloudSDKException as e:
+            print(f"[{metric}] 查询失败: {e}")
+
+        time.sleep(0.1)  # 避免触发频率限制
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/sandbox-monitor/examples/python/query_single_metric.py
+++ b/utils/sandbox-monitor/examples/python/query_single_metric.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+查询单个沙箱监控指标示例。
+
+使用前请设置环境变量：
+    export TENCENTCLOUD_SECRET_ID="<你的 SecretId>"
+    export TENCENTCLOUD_SECRET_KEY="<你的 SecretKey>"
+
+使用方式：
+    python query_single_metric.py --region ap-guangzhou --tool-id sdt-xxx --instance-id xxx --metric SandboxCpuUsagePercent
+"""
+import argparse
+import json
+import os
+from datetime import datetime, timedelta
+
+from tencentcloud.common import credential
+from tencentcloud.common.exception.tencent_cloud_sdk_exception import TencentCloudSDKException
+from tencentcloud.common.profile.client_profile import ClientProfile
+from tencentcloud.common.profile.http_profile import HttpProfile
+from tencentcloud.monitor.v20180724 import monitor_client, models
+
+
+ALL_METRICS = [
+    "SandboxCpuUsagePercent",
+    "SandboxCpuUsedCores",
+    "SandboxMemoryUsagePercent",
+    "SandboxMemoryUsedBytes",
+    "SandboxDiskReadBytesPerSecond",
+    "SandboxDiskWriteBytesPerSecond",
+    "SandboxFsUsagePercent",
+    "SandboxFsUsedBytes",
+    "SandboxNetworkRxBytesPerSecond",
+    "SandboxNetworkTxBytesPerSecond",
+]
+
+
+def query_sandbox_metric(
+    region: str,
+    tool_id: str,
+    instance_id: str,
+    metric_name: str,
+    start_time: str = None,
+    end_time: str = None,
+    period: int = 60,
+) -> dict:
+    """
+    查询沙箱监控指标。
+
+    Args:
+        region: 地域，如 "ap-guangzhou"
+        tool_id: 沙箱工具 ID，如 "sdt-0h5n0fil"
+        instance_id: 沙箱实例 ID
+        metric_name: 指标名，如 "SandboxCpuUsagePercent"
+        start_time: 开始时间 (ISO 8601)，默认 1 小时前
+        end_time: 结束时间 (ISO 8601)，默认当前时间
+        period: 统计周期，单位秒，默认 60
+
+    Returns:
+        GetMonitorData 响应字典
+    """
+    cred = credential.Credential(
+        os.environ["TENCENTCLOUD_SECRET_ID"],
+        os.environ["TENCENTCLOUD_SECRET_KEY"],
+    )
+
+    http_profile = HttpProfile()
+    http_profile.endpoint = "monitor.tencentcloudapi.com"
+    http_profile.reqMethod = "POST"
+
+    client_profile = ClientProfile()
+    client_profile.signMethod = "TC3-HMAC-SHA256"
+    client_profile.httpProfile = http_profile
+
+    client = monitor_client.MonitorClient(cred, region, client_profile)
+
+    # 默认时间范围：最近 1 小时
+    now = datetime.now().astimezone()
+    if not end_time:
+        end_time = now.strftime("%Y-%m-%dT%H:%M:%S%z")
+        end_time = end_time[:-2] + ":" + end_time[-2:]
+    if not start_time:
+        start = now - timedelta(hours=1)
+        start_time = start.strftime("%Y-%m-%dT%H:%M:%S%z")
+        start_time = start_time[:-2] + ":" + start_time[-2:]
+
+    payload = {
+        "Namespace": "QCE/AGS",
+        "MetricName": metric_name,
+        "Instances": [
+            {
+                "Dimensions": [
+                    {"Name": "tool_id", "Value": tool_id},
+                    {"Name": "instance_id", "Value": instance_id},
+                ]
+            }
+        ],
+        "Period": period,
+        "StartTime": start_time,
+        "EndTime": end_time,
+    }
+
+    req = models.GetMonitorDataRequest()
+    req.from_json_string(json.dumps(payload))
+
+    resp = client.GetMonitorData(req)
+    return json.loads(resp.to_json_string())
+
+
+def main():
+    parser = argparse.ArgumentParser(description="查询沙箱监控指标")
+    parser.add_argument("--region", required=True, help="地域，如 ap-guangzhou")
+    parser.add_argument("--tool-id", required=True, help="沙箱工具 ID，如 sdt-0h5n0fil")
+    parser.add_argument("--instance-id", required=True, help="沙箱实例 ID")
+    parser.add_argument("--metric", default="SandboxCpuUsagePercent",
+                        help="指标名，传 all 查询全部 10 个指标")
+    parser.add_argument("--period", type=int, default=60, help="统计周期（秒），默认 60")
+    parser.add_argument("--start", default=None, help="开始时间 (ISO 8601)，默认 1 小时前")
+    parser.add_argument("--end", default=None, help="结束时间 (ISO 8601)，默认当前时间")
+    args = parser.parse_args()
+
+    metrics = ALL_METRICS if args.metric.lower() == "all" else [args.metric]
+
+    try:
+        for metric_name in metrics:
+            result = query_sandbox_metric(
+                region=args.region,
+                tool_id=args.tool_id,
+                instance_id=args.instance_id,
+                metric_name=metric_name,
+                start_time=args.start,
+                end_time=args.end,
+                period=args.period,
+            )
+
+            # 解析数据点
+            data_points = result.get("DataPoints", [])
+            if data_points and data_points[0].get("Values"):
+                values = data_points[0]["Values"]
+                print(f"[{metric_name}] count={len(values)}, avg={sum(values)/len(values):.4f}, max={max(values):.4f}")
+            else:
+                print(f"[{metric_name}] 当前时间范围内无数据")
+
+    except TencentCloudSDKException as e:
+        print(f"查询失败: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/sandbox-monitor/examples/python/requirements.txt
+++ b/utils/sandbox-monitor/examples/python/requirements.txt
@@ -1,0 +1,2 @@
+tencentcloud-sdk-python-common>=3.1.99
+tencentcloud-sdk-python-monitor>=3.1.99

--- a/utils/sandbox-monitor/skill/sandbox-monitor.md
+++ b/utils/sandbox-monitor/skill/sandbox-monitor.md
@@ -1,0 +1,190 @@
+# AGS 沙箱监控查询 Skill
+
+当用户需要查询沙箱监控数据时，使用本 skill 帮助完成。
+
+## 能力
+
+本 skill 用于通过腾讯云云监控 `GetMonitorData` 接口查询 AGS 沙箱实例的运行监控指标。
+
+## 前置条件
+
+- 已设置环境变量 `TENCENTCLOUD_SECRET_ID` 和 `TENCENTCLOUD_SECRET_KEY`
+- 已知沙箱的 `tool_id` 和 `instance_id`
+- 已安装 Python 依赖：`pip install tencentcloud-sdk-python-common tencentcloud-sdk-python-monitor`
+
+## 监控指标
+
+共 10 个指标可查询：
+
+| MetricName | 单位 | 说明 |
+|---|---|---|
+| `SandboxCpuUsagePercent` | % | CPU 使用率 |
+| `SandboxCpuUsedCores` | cores | CPU 使用核数 |
+| `SandboxMemoryUsagePercent` | % | 内存使用率 |
+| `SandboxMemoryUsedBytes` | Bytes | 内存已使用字节数 |
+| `SandboxDiskReadBytesPerSecond` | Bytes/s | 磁盘读速率 |
+| `SandboxDiskWriteBytesPerSecond` | Bytes/s | 磁盘写速率 |
+| `SandboxFsUsagePercent` | % | 文件系统使用率 |
+| `SandboxFsUsedBytes` | Bytes | 文件系统已使用字节数 |
+| `SandboxNetworkRxBytesPerSecond` | Bytes/s | 网络入速率 |
+| `SandboxNetworkTxBytesPerSecond` | Bytes/s | 网络出速率 |
+
+## 查询流程
+
+当用户请求查询沙箱监控指标时，按以下步骤操作：
+
+### 步骤 1：确认参数
+
+向用户确认以下信息（如未提供）：
+- **Region**：沙箱运行地域（`ap-beijing` / `ap-shanghai` / `ap-guangzhou` / `ap-singapore` / `na-ashburn`）
+- **tool_id**：沙箱工具 ID（如 `sdt-ggdjgpcl`）
+- **instance_id**：沙箱实例 ID（如 `3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs`）
+- **指标**：要查询的指标名或 `all` 查询全部
+- **时间范围**：默认最近 1 小时
+
+### 步骤 2：执行查询
+
+使用以下 Python 脚本查询指标：
+
+```python
+import json
+import os
+from datetime import datetime, timedelta
+
+from tencentcloud.common import credential
+from tencentcloud.common.profile.client_profile import ClientProfile
+from tencentcloud.common.profile.http_profile import HttpProfile
+from tencentcloud.monitor.v20180724 import monitor_client, models
+
+
+def query_sandbox_metric(region, tool_id, instance_id, metric_name, start_time=None, end_time=None, period=60):
+    cred = credential.Credential(
+        os.environ["TENCENTCLOUD_SECRET_ID"],
+        os.environ["TENCENTCLOUD_SECRET_KEY"],
+    )
+
+    http_profile = HttpProfile()
+    http_profile.endpoint = "monitor.tencentcloudapi.com"
+    http_profile.reqMethod = "POST"
+
+    client_profile = ClientProfile()
+    client_profile.signMethod = "TC3-HMAC-SHA256"
+    client_profile.httpProfile = http_profile
+
+    client = monitor_client.MonitorClient(cred, region, client_profile)
+
+    now = datetime.now().astimezone()
+    if not end_time:
+        end_time = now.strftime("%Y-%m-%dT%H:%M:%S%z")
+        end_time = end_time[:-2] + ":" + end_time[-2:]
+    if not start_time:
+        start = now - timedelta(hours=1)
+        start_time = start.strftime("%Y-%m-%dT%H:%M:%S%z")
+        start_time = start_time[:-2] + ":" + start_time[-2:]
+
+    payload = {
+        "Namespace": "QCE/AGS",
+        "MetricName": metric_name,
+        "Instances": [
+            {
+                "Dimensions": [
+                    {"Name": "tool_id", "Value": tool_id},
+                    {"Name": "instance_id", "Value": instance_id},
+                ]
+            }
+        ],
+        "Period": period,
+        "StartTime": start_time,
+        "EndTime": end_time,
+    }
+
+    req = models.GetMonitorDataRequest()
+    req.from_json_string(json.dumps(payload))
+    resp = client.GetMonitorData(req)
+    return json.loads(resp.to_json_string())
+```
+
+### 步骤 3：解读结果
+
+查询结果中：
+- `DataPoints[].Timestamps`：Unix 时间戳数组（秒级）
+- `DataPoints[].Values`：对应时间点的指标值数组
+- 两者一一对应
+
+向用户展示：
+- 数据点数量
+- 平均值、最大值、最小值
+- 如有异常值（如 CPU 突增），主动指出
+
+### 步骤 4：问题排查
+
+如查询返回空数据，检查：
+1. 沙箱是否正在运行
+2. Region 是否与沙箱实际运行地域匹配
+3. 时间范围是否正确（新数据可能有 1-3 分钟延迟）
+4. tool_id 和 instance_id 是否正确
+
+如遇 SDK 异常，参考错误码：
+- `InvalidParameterValue`：参数错误，检查 Namespace/MetricName/Dimensions/Region
+- `LimitExceeded.LimitedAccess`：限频，降低并发
+- `InternalError`：内部错误，稍后重试
+
+## 查询全部指标的快速命令
+
+```bash
+export TENCENTCLOUD_SECRET_ID="<SecretId>"
+export TENCENTCLOUD_SECRET_KEY="<SecretKey>"
+
+python -c "
+import json, os, time
+from datetime import datetime, timedelta
+from tencentcloud.common import credential
+from tencentcloud.common.profile.client_profile import ClientProfile
+from tencentcloud.common.profile.http_profile import HttpProfile
+from tencentcloud.monitor.v20180724 import monitor_client, models
+
+ALL_METRICS = [
+    'SandboxCpuUsagePercent', 'SandboxCpuUsedCores',
+    'SandboxMemoryUsagePercent', 'SandboxMemoryUsedBytes',
+    'SandboxDiskReadBytesPerSecond', 'SandboxDiskWriteBytesPerSecond',
+    'SandboxFsUsagePercent', 'SandboxFsUsedBytes',
+    'SandboxNetworkRxBytesPerSecond', 'SandboxNetworkTxBytesPerSecond',
+]
+
+cred = credential.Credential(os.environ['TENCENTCLOUD_SECRET_ID'], os.environ['TENCENTCLOUD_SECRET_KEY'])
+hp = HttpProfile(); hp.endpoint = 'monitor.tencentcloudapi.com'; hp.reqMethod = 'POST'
+cp = ClientProfile(); cp.signMethod = 'TC3-HMAC-SHA256'; cp.httpProfile = hp
+client = monitor_client.MonitorClient(cred, 'REGION', cp)
+
+now = datetime.now().astimezone()
+start = now - timedelta(hours=1)
+fmt = lambda dt: dt.strftime('%Y-%m-%dT%H:%M:%S%z')[:-2] + ':' + dt.strftime('%z')[-2:]
+
+for m in ALL_METRICS:
+    payload = {'Namespace':'QCE/AGS','MetricName':m,'Instances':[{'Dimensions':[{'Name':'tool_id','Value':'TOOL_ID'},{'Name':'instance_id','Value':'INSTANCE_ID'}]}],'Period':60,'StartTime':fmt(start),'EndTime':fmt(now)}
+    req = models.GetMonitorDataRequest(); req.from_json_string(json.dumps(payload))
+    resp = json.loads(client.GetMonitorData(req).to_json_string())
+    dp = resp.get('DataPoints',[])
+    vals = dp[0].get('Values',[]) if dp else []
+    if vals: print(f'{m}: avg={sum(vals)/len(vals):.4f}, max={max(vals):.4f}, count={len(vals)}')
+    else: print(f'{m}: no data')
+    time.sleep(0.1)
+"
+```
+
+将上面命令中的 `REGION`、`TOOL_ID`、`INSTANCE_ID` 替换为实际值即可。
+
+## 关键参数说明
+
+| 参数 | 说明 | 示例 |
+|---|---|---|
+| Namespace | 固定值 | `QCE/AGS` |
+| Region | 沙箱运行地域 | `ap-guangzhou` |
+| Period | 统计周期（秒） | `60` |
+| Dimensions | 维度，只传 tool_id 和 instance_id | 见上方示例 |
+
+## 安全注意事项
+
+- 不要将 SecretId/SecretKey 写入代码仓库或日志
+- 使用环境变量传递凭证
+- 排查问题时只提供 RequestId，不要暴露密钥


### PR DESCRIPTION
Provide customer-facing documentation for querying AGS sandbox monitoring metrics via Tencent Cloud GetMonitorData API, including Python and Go SDK examples with CLI argument support, and a ready-to-use Claude Code skill.