### PR TITLE
docs(utils): query sandbox metrics by instance_id only

### DIFF
--- a/utils/sandbox-monitor/README.md
+++ b/utils/sandbox-monitor/README.md
@@ -43,14 +43,12 @@
 
 | 维度名 | 必填 | 示例 | 说明 |
 |---|:---:|---|---|
-| `tool_id` | 是 | `sdt-ggdjgpcl` | 沙箱工具 ID |
 | `instance_id` | 是 | `3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs` | 沙箱实例 ID |
 
 `Dimensions` 标准 JSON 格式：
 
 ```json
 [
-  {"Name": "tool_id", "Value": "sdt-ggdjgpcl"},
   {"Name": "instance_id", "Value": "3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs"}
 ]
 ```
@@ -94,7 +92,6 @@
   "Instances": [
     {
       "Dimensions": [
-        {"Name": "tool_id", "Value": "sdt-ggdjgpcl"},
         {"Name": "instance_id", "Value": "3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs"}
       ]
     }
@@ -112,7 +109,7 @@
 | `Namespace` | 是 | String | 固定为 `QCE/AGS` |
 | `MetricName` | 是 | String | 指标名，见上方指标列表 |
 | `Instances` | 是 | Array | 查询对象数组，单次最多 50 个实例 |
-| `Instances[].Dimensions` | 是 | Array | 只传 `tool_id` 和 `instance_id` |
+| `Instances[].Dimensions` | 是 | Array | 只传 `instance_id` |
 | `Period` | 否 | Integer | 统计周期，单位秒，建议 `60` |
 | `StartTime` | 否 | String | ISO 8601 时间，必须带时区（如 `+08:00`） |
 | `EndTime` | 否 | String | ISO 8601 时间，必须带时区 |
@@ -127,8 +124,7 @@
     "DataPoints": [
       {
         "Dimensions": [
-          {"Name": "instance_id", "Value": "3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs"},
-          {"Name": "tool_id", "Value": "sdt-ggdjgpcl"}
+          {"Name": "instance_id", "Value": "3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs"}
         ],
         "Timestamps": [1747634400, 1747634460, 1747634520],
         "Values": [0.12, 0.08, 0.15]
@@ -152,8 +148,7 @@
     "DataPoints": [
       {
         "Dimensions": [
-          {"Name": "instance_id", "Value": "3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs"},
-          {"Name": "tool_id", "Value": "sdt-ggdjgpcl"}
+          {"Name": "instance_id", "Value": "3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs"}
         ],
         "Timestamps": [],
         "Values": []
@@ -226,7 +221,6 @@ from tencentcloud.monitor.v20180724 import monitor_client, models
 
 def query_sandbox_metric(
     region: str,
-    tool_id: str,
     instance_id: str,
     metric_name: str,
     start_time: str = None,
@@ -238,7 +232,6 @@ def query_sandbox_metric(
 
     Args:
         region: 地域，如 "ap-guangzhou"
-        tool_id: 沙箱工具 ID，如 "sdt-ggdjgpcl"
         instance_id: 沙箱实例 ID
         metric_name: 指标名，如 "SandboxCpuUsagePercent"
         start_time: 开始时间 (ISO 8601)，默认 1 小时前
@@ -282,7 +275,6 @@ def query_sandbox_metric(
         "Instances": [
             {
                 "Dimensions": [
-                    {"Name": "tool_id", "Value": tool_id},
                     {"Name": "instance_id", "Value": instance_id},
                 ]
             }
@@ -304,7 +296,6 @@ if __name__ == "__main__":
     try:
         result = query_sandbox_metric(
             region="ap-guangzhou",
-            tool_id="sdt-ggdjgpcl",
             instance_id="3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs",
             metric_name="SandboxCpuUsagePercent",
         )
@@ -334,7 +325,6 @@ import time
 for metric in ALL_METRICS:
     result = query_sandbox_metric(
         region="ap-guangzhou",
-        tool_id="sdt-ggdjgpcl",
         instance_id="3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs",
         metric_name=metric,
     )
@@ -382,7 +372,7 @@ import (
 	monitor "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/monitor/v20180724"
 )
 
-func querySandboxMetric(region, toolID, instanceID, metricName string) (string, error) {
+func querySandboxMetric(region, instanceID, metricName string) (string, error) {
 	// 构造凭证
 	cred := common.NewCredential(
 		os.Getenv("TENCENTCLOUD_SECRET_ID"),
@@ -414,10 +404,6 @@ func querySandboxMetric(region, toolID, instanceID, metricName string) (string, 
 		{
 			Dimensions: []*monitor.Dimension{
 				{
-					Name:  common.StringPtr("tool_id"),
-					Value: common.StringPtr(toolID),
-				},
-				{
 					Name:  common.StringPtr("instance_id"),
 					Value: common.StringPtr(instanceID),
 				},
@@ -439,11 +425,10 @@ func querySandboxMetric(region, toolID, instanceID, metricName string) (string, 
 
 func main() {
 	region := "ap-guangzhou"
-	toolID := "sdt-ggdjgpcl"
 	instanceID := "3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs"
 	metricName := "SandboxCpuUsagePercent"
 
-	result, err := querySandboxMetric(region, toolID, instanceID, metricName)
+	result, err := querySandboxMetric(region, instanceID, metricName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "查询失败: %v\n", err)
 		os.Exit(1)
@@ -476,9 +461,9 @@ var allMetrics = []string{
 	"SandboxNetworkTxBytesPerSecond",
 }
 
-func queryAllMetrics(region, toolID, instanceID string) {
+func queryAllMetrics(region, instanceID string) {
 	for _, metric := range allMetrics {
-		result, err := querySandboxMetric(region, toolID, instanceID, metric)
+		result, err := querySandboxMetric(region, instanceID, metric)
 		if err != nil {
 			fmt.Printf("[%s] 查询失败: %v\n", metric, err)
 		} else {

--- a/utils/sandbox-monitor/examples/golang/main.go
+++ b/utils/sandbox-monitor/examples/golang/main.go
@@ -5,7 +5,7 @@
 //   export TENCENTCLOUD_SECRET_KEY="<你的 SecretKey>"
 //
 // 运行：
-//   go run main.go --region ap-guangzhou --tool-id sdt-0h5n0fil --instance-id xxx
+//   go run main.go --region ap-guangzhou --instance-id xxx
 
 package main
 
@@ -51,7 +51,7 @@ func createClient(region string) (*monitor.Client, error) {
 	return monitor.NewClient(cred, region, cpf)
 }
 
-func querySandboxMetric(client *monitor.Client, toolID, instanceID, metricName, startTime, endTime string) (string, error) {
+func querySandboxMetric(client *monitor.Client, instanceID, metricName, startTime, endTime string) (string, error) {
 	req := monitor.NewGetMonitorDataRequest()
 	req.Namespace = common.StringPtr("QCE/AGS")
 	req.MetricName = common.StringPtr(metricName)
@@ -61,10 +61,6 @@ func querySandboxMetric(client *monitor.Client, toolID, instanceID, metricName, 
 	req.Instances = []*monitor.Instance{
 		{
 			Dimensions: []*monitor.Dimension{
-				{
-					Name:  common.StringPtr("tool_id"),
-					Value: common.StringPtr(toolID),
-				},
 				{
 					Name:  common.StringPtr("instance_id"),
 					Value: common.StringPtr(instanceID),
@@ -86,13 +82,12 @@ func querySandboxMetric(client *monitor.Client, toolID, instanceID, metricName, 
 
 func main() {
 	region := flag.String("region", "ap-guangzhou", "地域")
-	toolID := flag.String("tool-id", "", "沙箱工具 ID (必填)")
 	instanceID := flag.String("instance-id", "", "沙箱实例 ID (必填)")
 	metric := flag.String("metric", "SandboxCpuUsagePercent", "指标名，传 all 查询全部")
 	flag.Parse()
 
-	if *toolID == "" || *instanceID == "" {
-		fmt.Fprintf(os.Stderr, "错误: --tool-id 和 --instance-id 为必填参数\n")
+	if *instanceID == "" {
+		fmt.Fprintf(os.Stderr, "错误: --instance-id 为必填参数\n")
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -104,7 +99,6 @@ func main() {
 
 	fmt.Printf("查询参数:\n")
 	fmt.Printf("  Region:      %s\n", *region)
-	fmt.Printf("  Tool ID:     %s\n", *toolID)
 	fmt.Printf("  Instance ID: %s\n", *instanceID)
 	fmt.Printf("  Metric:      %s\n", *metric)
 	fmt.Printf("  时间范围:    %s ~ %s\n", startTime, endTime)
@@ -124,7 +118,7 @@ func main() {
 	}
 
 	for _, m := range metrics {
-		result, err := querySandboxMetric(client, *toolID, *instanceID, m, startTime, endTime)
+		result, err := querySandboxMetric(client, *instanceID, m, startTime, endTime)
 		if err != nil {
 			fmt.Printf("[%s] 查询失败: %v\n", m, err)
 		} else {

--- a/utils/sandbox-monitor/examples/python/query_all_metrics.py
+++ b/utils/sandbox-monitor/examples/python/query_all_metrics.py
@@ -8,7 +8,7 @@
     export TENCENTCLOUD_SECRET_KEY="<你的 SecretKey>"
 
 使用方式：
-    python query_all_metrics.py --region ap-guangzhou --tool-id sdt-xxx --instance-id xxx
+    python query_all_metrics.py --region ap-guangzhou --instance-id xxx
 """
 import argparse
 import json
@@ -57,7 +57,6 @@ def create_monitor_client(region: str) -> monitor_client.MonitorClient:
 
 def query_metric(
     client: monitor_client.MonitorClient,
-    tool_id: str,
     instance_id: str,
     metric_name: str,
     start_time: str,
@@ -71,7 +70,6 @@ def query_metric(
         "Instances": [
             {
                 "Dimensions": [
-                    {"Name": "tool_id", "Value": tool_id},
                     {"Name": "instance_id", "Value": instance_id},
                 ]
             }
@@ -96,35 +94,31 @@ def format_iso_time(dt: datetime) -> str:
 def main():
     parser = argparse.ArgumentParser(description="批量查询沙箱全部监控指标")
     parser.add_argument("--region", required=True, help="地域，如 ap-guangzhou")
-    parser.add_argument("--tool-id", required=True, help="沙箱工具 ID，如 sdt-0h5n0fil")
     parser.add_argument("--instance-id", required=True, help="沙箱实例 ID")
     args = parser.parse_args()
 
-    REGION = args.region
-    TOOL_ID = args.tool_id
-    INSTANCE_ID = args.instance_id
+    region = args.region
+    instance_id = args.instance_id
 
     now = datetime.now().astimezone()
     start = now - timedelta(hours=1)
     start_time = format_iso_time(start)
     end_time = format_iso_time(now)
 
-    print(f"查询参数:")
-    print(f"  Region:      {REGION}")
-    print(f"  Tool ID:     {TOOL_ID}")
-    print(f"  Instance ID: {INSTANCE_ID}")
+    print("查询参数:")
+    print(f"  Region:      {region}")
+    print(f"  Instance ID: {instance_id}")
     print(f"  时间范围:    {start_time} ~ {end_time}")
-    print(f"  统计周期:    60s")
+    print("  统计周期:    60s")
     print("=" * 70)
 
-    client = create_monitor_client(REGION)
+    client = create_monitor_client(region)
 
     for metric in ALL_METRICS:
         try:
             result = query_metric(
                 client=client,
-                tool_id=TOOL_ID,
-                instance_id=INSTANCE_ID,
+                instance_id=instance_id,
                 metric_name=metric,
                 start_time=start_time,
                 end_time=end_time,

--- a/utils/sandbox-monitor/examples/python/query_single_metric.py
+++ b/utils/sandbox-monitor/examples/python/query_single_metric.py
@@ -8,7 +8,7 @@
     export TENCENTCLOUD_SECRET_KEY="<你的 SecretKey>"
 
 使用方式：
-    python query_single_metric.py --region ap-guangzhou --tool-id sdt-xxx --instance-id xxx --metric SandboxCpuUsagePercent
+    python query_single_metric.py --region ap-guangzhou --instance-id xxx --metric SandboxCpuUsagePercent
 """
 import argparse
 import json
@@ -38,7 +38,6 @@ ALL_METRICS = [
 
 def query_sandbox_metric(
     region: str,
-    tool_id: str,
     instance_id: str,
     metric_name: str,
     start_time: str = None,
@@ -50,7 +49,6 @@ def query_sandbox_metric(
 
     Args:
         region: 地域，如 "ap-guangzhou"
-        tool_id: 沙箱工具 ID，如 "sdt-0h5n0fil"
         instance_id: 沙箱实例 ID
         metric_name: 指标名，如 "SandboxCpuUsagePercent"
         start_time: 开始时间 (ISO 8601)，默认 1 小时前
@@ -91,7 +89,6 @@ def query_sandbox_metric(
         "Instances": [
             {
                 "Dimensions": [
-                    {"Name": "tool_id", "Value": tool_id},
                     {"Name": "instance_id", "Value": instance_id},
                 ]
             }
@@ -111,10 +108,12 @@ def query_sandbox_metric(
 def main():
     parser = argparse.ArgumentParser(description="查询沙箱监控指标")
     parser.add_argument("--region", required=True, help="地域，如 ap-guangzhou")
-    parser.add_argument("--tool-id", required=True, help="沙箱工具 ID，如 sdt-0h5n0fil")
     parser.add_argument("--instance-id", required=True, help="沙箱实例 ID")
-    parser.add_argument("--metric", default="SandboxCpuUsagePercent",
-                        help="指标名，传 all 查询全部 10 个指标")
+    parser.add_argument(
+        "--metric",
+        default="SandboxCpuUsagePercent",
+        help="指标名，传 all 查询全部 10 个指标",
+    )
     parser.add_argument("--period", type=int, default=60, help="统计周期（秒），默认 60")
     parser.add_argument("--start", default=None, help="开始时间 (ISO 8601)，默认 1 小时前")
     parser.add_argument("--end", default=None, help="结束时间 (ISO 8601)，默认当前时间")
@@ -126,7 +125,6 @@ def main():
         for metric_name in metrics:
             result = query_sandbox_metric(
                 region=args.region,
-                tool_id=args.tool_id,
                 instance_id=args.instance_id,
                 metric_name=metric_name,
                 start_time=args.start,
@@ -138,7 +136,10 @@ def main():
             data_points = result.get("DataPoints", [])
             if data_points and data_points[0].get("Values"):
                 values = data_points[0]["Values"]
-                print(f"[{metric_name}] count={len(values)}, avg={sum(values)/len(values):.4f}, max={max(values):.4f}")
+                print(
+                    f"[{metric_name}] count={len(values)}, "
+                    f"avg={sum(values)/len(values):.4f}, max={max(values):.4f}"
+                )
             else:
                 print(f"[{metric_name}] 当前时间范围内无数据")
 

--- a/utils/sandbox-monitor/skill/sandbox-monitor.md
+++ b/utils/sandbox-monitor/skill/sandbox-monitor.md
@@ -9,7 +9,7 @@
 ## 前置条件
 
 - 已设置环境变量 `TENCENTCLOUD_SECRET_ID` 和 `TENCENTCLOUD_SECRET_KEY`
-- 已知沙箱的 `tool_id` 和 `instance_id`
+- 已知沙箱的 `instance_id`
 - 已安装 Python 依赖：`pip install tencentcloud-sdk-python-common tencentcloud-sdk-python-monitor`
 
 ## 监控指标
@@ -37,7 +37,6 @@
 
 向用户确认以下信息（如未提供）：
 - **Region**：沙箱运行地域（`ap-beijing` / `ap-shanghai` / `ap-guangzhou` / `ap-singapore` / `na-ashburn`）
-- **tool_id**：沙箱工具 ID（如 `sdt-ggdjgpcl`）
 - **instance_id**：沙箱实例 ID（如 `3vixj4szpniara3tu7wyhg35nbr27w4d7223wexs`）
 - **指标**：要查询的指标名或 `all` 查询全部
 - **时间范围**：默认最近 1 小时
@@ -57,7 +56,7 @@ from tencentcloud.common.profile.http_profile import HttpProfile
 from tencentcloud.monitor.v20180724 import monitor_client, models
 
 
-def query_sandbox_metric(region, tool_id, instance_id, metric_name, start_time=None, end_time=None, period=60):
+def query_sandbox_metric(region, instance_id, metric_name, start_time=None, end_time=None, period=60):
     cred = credential.Credential(
         os.environ["TENCENTCLOUD_SECRET_ID"],
         os.environ["TENCENTCLOUD_SECRET_KEY"],
@@ -88,7 +87,6 @@ def query_sandbox_metric(region, tool_id, instance_id, metric_name, start_time=N
         "Instances": [
             {
                 "Dimensions": [
-                    {"Name": "tool_id", "Value": tool_id},
                     {"Name": "instance_id", "Value": instance_id},
                 ]
             }
@@ -102,6 +100,13 @@ def query_sandbox_metric(region, tool_id, instance_id, metric_name, start_time=N
     req.from_json_string(json.dumps(payload))
     resp = client.GetMonitorData(req)
     return json.loads(resp.to_json_string())
+```
+
+也可直接运行仓库示例：
+
+```bash
+cd utils/sandbox-monitor/examples/python
+python query_all_metrics.py --region ap-guangzhou --instance-id <instance_id>
 ```
 
 ### 步骤 3：解读结果
@@ -122,7 +127,7 @@ def query_sandbox_metric(region, tool_id, instance_id, metric_name, start_time=N
 1. 沙箱是否正在运行
 2. Region 是否与沙箱实际运行地域匹配
 3. 时间范围是否正确（新数据可能有 1-3 分钟延迟）
-4. tool_id 和 instance_id 是否正确
+4. instance_id 是否正确
 
 如遇 SDK 异常，参考错误码：
 - `InvalidParameterValue`：参数错误，检查 Namespace/MetricName/Dimensions/Region
@@ -161,7 +166,7 @@ start = now - timedelta(hours=1)
 fmt = lambda dt: dt.strftime('%Y-%m-%dT%H:%M:%S%z')[:-2] + ':' + dt.strftime('%z')[-2:]
 
 for m in ALL_METRICS:
-    payload = {'Namespace':'QCE/AGS','MetricName':m,'Instances':[{'Dimensions':[{'Name':'tool_id','Value':'TOOL_ID'},{'Name':'instance_id','Value':'INSTANCE_ID'}]}],'Period':60,'StartTime':fmt(start),'EndTime':fmt(now)}
+    payload = {'Namespace':'QCE/AGS','MetricName':m,'Instances':[{'Dimensions':[{'Name':'instance_id','Value':'INSTANCE_ID'}]}],'Period':60,'StartTime':fmt(start),'EndTime':fmt(now)}
     req = models.GetMonitorDataRequest(); req.from_json_string(json.dumps(payload))
     resp = json.loads(client.GetMonitorData(req).to_json_string())
     dp = resp.get('DataPoints',[])
@@ -172,7 +177,7 @@ for m in ALL_METRICS:
 "
 ```
 
-将上面命令中的 `REGION`、`TOOL_ID`、`INSTANCE_ID` 替换为实际值即可。
+将上面命令中的 `REGION`、`INSTANCE_ID` 替换为实际值即可。
 
 ## 关键参数说明
 
@@ -181,7 +186,7 @@ for m in ALL_METRICS:
 | Namespace | 固定值 | `QCE/AGS` |
 | Region | 沙箱运行地域 | `ap-guangzhou` |
 | Period | 统计周期（秒） | `60` |
-| Dimensions | 维度，只传 tool_id 和 instance_id | 见上方示例 |
+| Dimensions | 维度，只传 instance_id | 见上方示例 |
 
 ## 安全注意事项
 


### PR DESCRIPTION
Remove tool_id from GetMonitorData dimensions in docs, skill, and examples.