### PR TITLE
feat(skills): add ags reference skill and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Examples, tutorials, and utilities for building on Tencent Cloud Agent Sandbox /
 
 ## What this repo contains
 
+- **Skills**: reference Agent Skill example for AGS; see [`skills/README.md`](./skills/README.md)
 - **Tutorials**: SDK and notebook-based onboarding
 - **Examples**: runnable browser, code, mobile, Go, and OSWorld demos
 - **Benchmarks**: k6 stress scripts
@@ -23,8 +24,21 @@ Examples, tutorials, and utilities for building on Tencent Cloud Agent Sandbox /
 
 - Most Python examples in `examples/` require **Python >= 3.12**
 - `examples/osworld-ags` currently requires **Python 3.10**
+- `uv` can manage both interpreters.
 
-`uv` can manage both interpreters.
+### agr CLI
+
+The `ags` reference Skill example uses the `agr` CLI:
+
+```bash
+# One-line install (macOS / Linux)
+curl -fsSL https://github.com/TencentCloudAgentRuntime/ags-cli/releases/latest/download/install.sh | sh
+
+# Or via go install
+go install github.com/TencentCloudAgentRuntime/ags-cli/cmd/agr@latest
+
+agr version -o json
+```
 
 ## Common environment variables
 
@@ -82,6 +96,22 @@ You can also enter an example directory directly and run its local `make setup` 
 | `shop-assistant` | Python + browser sandbox | E-commerce search / add-to-cart demo |
 
 See `examples/README.md` for per-example details and a starter/advanced/heavy picker.
+
+## Skills overview
+
+The **`ags`** skill is a reference Agent Skill example for AGS. It demonstrates CLI-first AGS workflows with `agr`.
+
+| Skill | Path | What it covers |
+|---|---|---|
+| `ags` | [`skills/ags/SKILL.md`](./skills/ags/SKILL.md) | CLI-first AGS workflows with `agr`: tools, instances, code/shell execution, files, browser/mobile, storage mounts, API keys, debug instances, tool fork, and raw API fallback. |
+
+Add from GitHub with the `skills` CLI:
+
+```bash
+npx skills add TencentCloudAgentRuntime/ags-cookbook --skill ags
+```
+
+See [`skills/README.md`](./skills/README.md) for the skill index and the progressive disclosure structure.
 
 ## Important DX notes
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,6 +4,7 @@
 
 ## 仓库内容
 
+- **skills/**：AGS 的参考 Agent Skill 示例；详见 [`skills/README.md`](./skills/README.md)
 - **tutorials/**：SDK / Notebook 教程
 - **examples/**：可运行的浏览器、代码、移动端、Go、OSWorld 示例
 - **benchmarks/**：k6 压测脚本
@@ -23,8 +24,21 @@
 
 - `examples/` 下多数 Python 示例要求 **Python >= 3.12**
 - `examples/osworld-ags` 当前要求 **Python 3.10**
+- 建议统一使用 `uv` 管理解释器。
 
-建议统一使用 `uv` 管理解释器。
+### agr CLI
+
+`ags` 参考 Skill 示例使用 `agr` CLI：
+
+```bash
+# 一键安装（macOS / Linux）
+curl -fsSL https://github.com/TencentCloudAgentRuntime/ags-cli/releases/latest/download/install.sh | sh
+
+# 或通过 go install
+go install github.com/TencentCloudAgentRuntime/ags-cli/cmd/agr@latest
+
+agr version -o json
+```
 
 ## 常用环境变量
 
@@ -79,6 +93,22 @@ make example-run EXAMPLE=mini-rl
 | `shop-assistant` | Python + 浏览器沙箱 | 搜索 / 加购演示 |
 
 详见 `examples/README_zh.md`，其中包含各示例的使用说明与推荐阅读顺序。
+
+## Skills 概览
+
+**`ags`** 是 AGS 的参考 Agent Skill 示例，展示基于 `agr` 的 CLI-first AGS 工作流。
+
+| Skill | 路径 | 覆盖范围 |
+|---|---|---|
+| `ags` | [`skills/ags/SKILL.md`](./skills/ags/SKILL.md) | CLI-first AGS 工作流：工具、实例、代码/Shell 执行、文件传输、浏览器/移动端、存储挂载、API Key、调试实例、工具复制、原始 API 透传 |
+
+通过 `skills` CLI 从 GitHub 添加：
+
+```bash
+npx skills add TencentCloudAgentRuntime/ags-cookbook --skill ags
+```
+
+索引与渐进式披露结构见 [`skills/README.md`](./skills/README.md)。
 
 ## 重要 DX 说明
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,36 @@
+# AGS Cookbook — Agent Skill
+
+## Reference Skill example
+
+| Skill | Path | Description |
+|-------|------|-------------|
+| **ags** | [`ags/SKILL.md`](./ags/SKILL.md) | Reference example for CLI-first AGS workflows with `agr`. |
+
+This directory is a reference Agent Skill example for AGS.
+
+Add from GitHub with the `skills` CLI:
+
+```bash
+npx skills add TencentCloudAgentRuntime/ags-cookbook --skill ags
+```
+
+Install the CLI:
+
+```bash
+# One-line install (macOS / Linux)
+curl -fsSL https://github.com/TencentCloudAgentRuntime/ags-cli/releases/latest/download/install.sh | sh
+
+# Or via go install
+go install github.com/TencentCloudAgentRuntime/ags-cli/cmd/agr@latest
+
+agr version -o json
+```
+
+The main Skill follows progressive disclosure:
+
+- Load [`ags/SKILL.md`](./ags/SKILL.md) for day-to-day CLI work.
+- Open [`ags/references/mount-templates.md`](./ags/references/mount-templates.md) only for storage JSON examples.
+- Open [`ags/references/vpc-networking.md`](./ags/references/vpc-networking.md) for VPC mode, subnets, security groups, and private service access.
+- Open [`ags/references/custom-images.md`](./ags/references/custom-images.md) for custom-image services, ports, probes, resources, env vars, registry access, and per-instance overrides.
+- Open [`ags/references/advanced-workflows.md`](./ags/references/advanced-workflows.md) for browser/mobile/API key/raw API/image pre-cache/debug workflows.
+- Open [`ags/references/troubleshooting.md`](./ags/references/troubleshooting.md) for failures, status interpretation, exit codes, and cleanup issues.

--- a/skills/ags/SKILL.md
+++ b/skills/ags/SKILL.md
@@ -1,0 +1,388 @@
+---
+name: ags
+description: >-
+  Reference Agent Skill example for Tencent Cloud AGS / Agent Runtime workflows
+  using the agr CLI. Covers AGS sandbox tools and instances, code or shell
+  execution in AGS, file transfer, browser/mobile sandboxes, storage mounts,
+  API keys, image pre-cache, debug instances, tool fork, and raw AGS Cloud API
+  workflows.
+  Do not use for generic local shell, Docker, Kubernetes, or non-Tencent Cloud
+  sandbox tasks.
+when_to_use: >-
+  Trigger on AGS, Agent Runtime, agr, Tencent Cloud sandbox, 腾讯云沙箱, AGS 沙箱,
+  code execution, shell execution, file transfer, browser sandbox, mobile
+  sandbox, CFS/COS/Image storage mounts, API keys, image pre-cache, debug
+  instance, tool fork, or AGS Cloud API requests.
+---
+
+# AGS With `agr`
+
+Use `agr` for all AGS work.
+
+## Start Here
+
+First check the local CLI and credentials:
+
+```bash
+command -v agr
+agr version -o json
+agr status -o json
+```
+
+If `agr` is missing or outdated, install or upgrade it before running AGS workflows.
+
+## Requirements
+
+- **agr CLI (latest)** — run `agr version -o json` to check. Always use the latest release; see Install below if missing or outdated.
+- **Tencent Cloud SecretId/SecretKey** — from [CAM Console](https://console.cloud.tencent.com/cam/capi). Temporary STS credentials also supported via `TENCENTCLOUD_TOKEN`.
+- **Config**: `~/.agr/config.toml` by default, or `--config /path/to/config.toml`.
+
+## Install
+
+If `agr` is missing or outdated, install or upgrade to the latest release:
+
+```bash
+# One-line install / upgrade (macOS / Linux)
+curl -fsSL https://github.com/TencentCloudAgentRuntime/ags-cli/releases/latest/download/install.sh | sh
+
+# Or via go install (note: commit/built fields show "n/a")
+go install github.com/TencentCloudAgentRuntime/ags-cli/cmd/agr@latest
+```
+
+Verify: `agr version`. If the installed version is not the latest, re-run the install command above.
+
+## Configure Credentials
+
+```bash
+export TENCENTCLOUD_SECRET_ID="..."
+export TENCENTCLOUD_SECRET_KEY="..."
+agr init --secret-id "$TENCENTCLOUD_SECRET_ID" --secret-key "$TENCENTCLOUD_SECRET_KEY" --overwrite -o json
+agr status -o json
+agr doctor -o json
+```
+
+Temporary STS credentials:
+
+```bash
+export TENCENTCLOUD_SECRET_ID="tmp-id"
+export TENCENTCLOUD_SECRET_KEY="tmp-key"
+export TENCENTCLOUD_TOKEN="tmp-session-token"
+```
+
+Or pass `--token` on any command, or `agr config set token=<token>`.
+
+Config priority: `--flag` > env vars > `~/.agr/config.toml` > defaults. Use `agr status` to inspect resolved values.
+
+## Safety Rules
+
+- If the user explicitly asks to create, fork, run, or debug an AGS resource, proceed with temporary, clearly named resources.
+- Confirm before deleting resources, creating long-lived resources, using unclear billing/permission settings, or changing non-temporary production resources.
+- Use explicit `--timeout` for temporary instances.
+- Clean up temporary Instances and Tools with `instance delete` and `tool delete`.
+- Do not print or commit `SecretId`, `SecretKey`, API keys, tokens, or RoleArn values.
+- Prefer `--tool-id` in scripts. Use `--tool-name` only for known-unique temporary resources.
+- Use `-o json` for automation. Use `--stream -o ndjson` only for streaming `code run` / `exec`.
+
+## Choose The Right Reference
+
+Keep this file as the core workflow. Load extra files only when the task needs them:
+
+| Need | Read |
+| --- | --- |
+| COS/CFS/Image mount JSON and path rules | [references/mount-templates.md](references/mount-templates.md) |
+| VPC networking, private subnets, security groups, private service access | [references/vpc-networking.md](references/vpc-networking.md) |
+| Custom-image services, ports, probes, resources, env, registry access | [references/custom-images.md](references/custom-images.md) |
+| Browser, mobile, API keys, raw API, image pre-cache, interactive login/proxy | [references/advanced-workflows.md](references/advanced-workflows.md) |
+| Statuses, errors, CLI drift, cleanup problems | [references/troubleshooting.md](references/troubleshooting.md) |
+
+## Common Task Patterns
+
+- Run code once: check `agr status`, create or reuse a `code-interpreter` Tool, create an Instance with `--timeout`, wait for `RUNNING`, run `instance code run`, then delete temporary resources.
+- Work with files: create or reuse an Instance, upload local files, run code or shell, download artifacts, then delete temporary resources.
+- Fork an existing Tool: inspect the source Tool with `tool get`, choose a unique new `--tool-name`, pass only the intended overrides to `tool fork`, verify the fork with `tool get`.
+- Add storage while creating or forking a Tool: read [references/mount-templates.md](references/mount-templates.md), include `--storage-mounts` or a full `--request`, ensure `RoleArn` is present when the mount requires it, then create a test Instance.
+- Create a custom-image service: read [references/custom-images.md](references/custom-images.md), use a full request JSON with image, command, ports, resources, and probe, then create an Instance and verify the service with `instance proxy` or `exec`.
+- Use VPC networking: read [references/vpc-networking.md](references/vpc-networking.md), collect subnet/security group IDs and the private target to test, then create or fork a new Tool with `NetworkMode: "VPC"`. Do not update an existing Tool into VPC mode.
+- Debug a Tool: verify the source Tool has `RoleArn`, run `instance debug`, wait for `RUNNING`, and use `login` or `proxy` only when the user asks for an interactive session.
+
+## Mental Model
+
+| Object | Meaning |
+| --- | --- |
+| Tool | Reusable sandbox template: type, network, timeout, storage, image/custom config. |
+| Instance | Running sandbox created from a Tool. Code, shell, files, ports, browser/mobile happen here. |
+| API Key | Credential for E2B SDK / MCP paths, not Cloud API management. |
+| Sandbox Token | Short-lived access credential for one Instance. |
+
+CLI / Cloud API management uses Tencent Cloud `SecretId` / `SecretKey` (plus optional STS `Token`) with CAM permissions.
+
+## Output Rules
+
+JSON responses use an `agr.v1` envelope with `Status`, `Data`, `Failure`, `Warnings`, and `Meta`.
+
+```bash
+agr tool list --limit 20 -o json
+agr tool list --limit 20 -o json --jq '.Data'
+```
+
+Rules:
+
+- `--jq` requires `-o json`.
+- `--stream` is incompatible with `-o json`; use text or `-o ndjson`.
+- `agr instance login` and `agr instance proxy` are interactive and do not return JSON.
+- On failure, inspect `.Failure.Code` / `.Failure.Hint`, then run `agr explain <CODE> -o json`.
+- Server-side errors now include `RequestId` alongside `Code` and `Message`.
+
+Exit codes: `0` success, `1` error, `2` usage, `4` auth, `255` remote_execution_failed. See `agr schema -o json --jq '.Data.ExitCodes'` for full list.
+
+## Create A Tool
+
+Use CLI short type names: `browser`, `code-interpreter`, `mobile`, `osworld`, `custom`. Do not pass Cloud API enum values.
+
+```bash
+tool_name="code-$(date +%s)-$$"
+tool_id=$(agr tool create \
+  --tool-name "$tool_name" \
+  --tool-type code-interpreter \
+  --network-configuration '{"NetworkMode":"SANDBOX"}' \
+  -o json --jq '.Data.ToolId')
+
+# Verify tool is ready
+agr tool get "$tool_id" -o json
+```
+
+**Key flags for `tool create`:**
+
+| Flag | Type | Notes |
+| --- | --- | --- |
+| `--tool-name` | string | **Required.** Must be unique within your AppId. Use a timestamp+PID suffix to avoid collisions. |
+| `--tool-type` | string | **Required.** One of: `browser`, `code-interpreter`, `mobile`, `osworld`, `custom`. |
+| `--network-configuration` | JSON | `{"NetworkMode":"SANDBOX\|PUBLIC\|VPC"}`. VPC mode also needs `VpcConfig.SubnetIds` and `VpcConfig.SecurityGroupIds`. |
+| `--default-timeout` | duration | Default instance timeout, e.g. `30m`, `1h`, `2h30m`. Instances inherit this unless overridden on `instance create`. |
+| `--storage-mounts` | JSON / `@file` | Array of mount objects. See [references/mount-templates.md](references/mount-templates.md) for COS/CFS/Image examples. Requires `--role-arn` when the storage source needs cloud access. |
+| `--role-arn` | string | CAM role ARN required for COS/CFS mounts, private image registries, and debug instances. Format: `qcs::cam::uin/<uin>:roleName/<name>`. |
+| `--tags` | JSON / `@file` | Array of `{"Key":"...","Value":"..."}` objects for resource tagging. |
+| `--generate-skeleton` | — | Print a full JSON skeleton for `--request`. Use this first for complex configurations. |
+| `--request` | JSON / `@file` / `-` | Supply the full request body as JSON when many nested fields are needed. |
+
+Network modes:
+
+| Mode | Use |
+| --- | --- |
+| `SANDBOX` | No Internet/VPC outbound; local code or mounted data. |
+| `PUBLIC` | Internet access for packages, APIs, public web. |
+| `VPC` | Private subnet/security group access. |
+
+For custom images, VPC configs, tags, storage mounts, or many nested fields, start from the skeleton:
+
+```bash
+agr tool create --generate-skeleton > tool.json
+# Edit tool.json, then:
+agr tool create --request @tool.json -o json
+```
+
+**`tool create` behavior notes:**
+- Tool name must be unique in your AppId; the create call fails immediately with a name conflict error if it already exists.
+- `--storage-mounts` and `--role-arn` are independent flags; both can be supplied alongside `--request`.
+- `--network-configuration` in `--request` overrides the `--network-configuration` flag if both are passed. Prefer one or the other.
+
+**`tool list` filters:**
+
+```bash
+agr tool list --tool-type code-interpreter -o json
+agr tool list --limit 20 -o json --jq '.Data.Items[].ToolId'
+```
+
+## Fork A Tool
+
+Copy an existing Tool's settings into a new Tool with optional overrides:
+
+```bash
+agr tool get "$source_tool_id" -o json
+
+forked_id=$(agr tool fork "$source_tool_id" \
+  --tool-name "forked-$(date +%s)-$$" \
+  --network-configuration '{"NetworkMode":"PUBLIC"}' \
+  -o json --jq '.Data.ToolId')
+
+agr tool get "$forked_id" -o json
+```
+
+`agr tool fork` copies all creatable settings from the source. Pass any `tool create` flags to override specific fields. For CFS/COS/Image mounts while forking, read [references/mount-templates.md](references/mount-templates.md).
+
+## Update A Tool
+
+```bash
+agr tool update "$tool_id" --description "Updated description" -o json
+agr tool list -o json
+agr tool get "$tool_id" -o json
+```
+
+Tool names cannot be updated. Use `tool update` only for supported mutable fields such as description, tags, network configuration, and custom configuration. Do not update an existing Tool into VPC mode; create or fork a new Tool with VPC networking instead.
+
+`agr tool update` does not expose a direct `--storage-mounts` flag. If the user wants to add or replace storage mounts on an existing Tool, prefer forking it into a new Tool with the intended `--storage-mounts`; see [references/mount-templates.md](references/mount-templates.md).
+
+## Create And Manage An Instance
+
+```bash
+instance_id=$(agr instance create \
+  --tool-id "$tool_id" \
+  --timeout 30m \
+  -o json --jq '.Data.InstanceId')
+
+# Poll until RUNNING before sending work
+agr instance get "$instance_id" -o json
+```
+
+**Key flags for `instance create`:**
+
+| Flag | Type | Notes |
+| --- | --- | --- |
+| `--tool-id` | string | **Required** (or `--tool-name`). Specifies the Tool template to instantiate. |
+| `--tool-name` | string | Alternative to `--tool-id`. Use only for known-unique tool names. |
+| `--timeout` | duration | Override the Tool's default timeout, e.g. `30m`, `1h`, `2h30m`. Always set this for temporary instances. |
+| `--mount-options` | JSON / `@file` / `-` | Per-instance mount overrides. Can only reference mount names already defined in the Tool's `StorageMounts`. Supports `MountPath`, `SubPath`, `ReadOnly` overrides. |
+| `--metadata` | JSON / `@file` / `-` | Arbitrary key-value metadata attached to the instance. |
+| `--auth-mode` | string | `DEFAULT` (inherited from Tool), `TOKEN` (sandbox token required), `NONE` (no auth), `PUBLIC` (no auth, public access). |
+
+`--mount-options` lets you re-use one Tool mount under multiple paths in a single instance run:
+
+```bash
+agr instance create \
+  --tool-id "$tool_id" \
+  --timeout 30m \
+  --mount-options '[
+    {"Name":"cos-assets","MountPath":"/workspace/input","SubPath":"run-001","ReadOnly":true},
+    {"Name":"cos-assets","MountPath":"/workspace/output","SubPath":"run-002","ReadOnly":false}
+  ]' \
+  -o json --jq '.Data.InstanceId'
+```
+
+**Instance status values:**
+
+Instance responses may include these status values:
+
+```text
+STARTING, RUNNING, FAILED, STOPPING, STOPPED,
+STARTING_FAILED, STOPPING_FAILED,
+PAUSED, PAUSE_FAILED, RESUME_FAILED
+```
+
+Some command help text may list only a subset of status filter values. If status filtering is needed, prefer `agr instance list --help` / `agr schema -o json` for the installed CLI's accepted filter values.
+
+Only `RUNNING` is safe for code, shell, file, browser/mobile, or port operations. `STARTING` is not ready — poll `instance get` before proceeding.
+
+**Useful `instance list` filters:**
+
+```bash
+agr instance list --tool-id "$tool_id" -o json
+agr instance list --filters '[{"Name":"Status","Values":["RUNNING"]}]' -o json
+```
+
+Lifecycle:
+
+```bash
+agr instance update "$instance_id" --timeout 1h -o json
+agr instance pause "$instance_id" -o json
+agr instance resume "$instance_id" -o json
+agr instance delete "$instance_id" --ignore-not-found -o json
+```
+
+**Common pitfalls:**
+
+| Problem | Cause | Fix |
+| --- | --- | --- |
+| Code/exec fails with "instance not ready" | Called before status is RUNNING | Always check status == RUNNING before sending work |
+| `--mount-options` name not found | Name not in Tool's StorageMounts | Check `tool get` to see defined mount names |
+| `--role-arn` missing for storage mount | Tool lacks CAM role | Add `--role-arn` when creating or forking the Tool |
+
+## Debug An Instance
+
+Creates a temporary debug Tool (start command switched to `/envd`, envd image mounted), then starts an Instance from it. The source Tool **must** have `RoleArn` configured.
+
+```bash
+debug_id=$(agr instance debug \
+  --tool-id "$tool_id" \
+  --timeout 30m \
+  -o json --jq '.Data.InstanceId')
+```
+
+| Flag | Notes |
+| --- | --- |
+| `--tool-id` / `--tool-name` | Identify the source Tool. |
+| `--timeout` | Debug instance lifetime (default `1h`). |
+| `--mount-options` | JSON / `@file` / `-` — per-instance mount overrides. |
+| `--metadata` | JSON / `@file` / `-` — arbitrary metadata. |
+| `--custom-configuration` | JSON / `@file` / `-` — custom start config overrides. |
+
+## Run Code Or Shell
+
+```bash
+agr instance code run "$instance_id" -l python -c "print('hello')" -o json
+agr instance code run "$instance_id" -l bash -c "echo hello" -o json
+agr instance exec "$instance_id" -o json -- pwd
+agr instance exec "$instance_id" -o json --cwd /workspace --env APP_ENV=prod -- python app.py
+```
+
+Streaming:
+
+```bash
+agr instance code run "$instance_id" --stream -o ndjson -c "import time; [print(i) or time.sleep(1) for i in range(3)]"
+agr instance exec "$instance_id" --stream -o ndjson -- tail -f /var/log/app.log
+```
+
+Temporary one-shot:
+
+```bash
+agr instance code run --create-temp-instance --tool-id "$tool_id" -c "print(42)" -o json
+```
+
+`--cleanup` options: `always` (default), `success`, `never`. JSON output includes `Data.ExecutionContext.SandboxInstanceId` and `Data.ExecutionContext.Cleanup`.
+
+Supported `code run` languages: `python`, `javascript`, `typescript`, `r`, `java`, `bash`.
+
+## Transfer Files
+
+```bash
+agr instance file upload "$instance_id" ./local.csv /workspace/local.csv -o json
+agr instance file download "$instance_id" /workspace/result.json ./result.json -o json
+```
+
+Both commands support `--user`.
+
+## Manage Config
+
+```bash
+agr config show          # show resolved config + sources
+agr config set region=ap-beijing
+agr config set token=<sts-session-token>
+agr config path          # show config file location
+```
+
+Use `agr status` to verify resolved values including credentials.
+
+## Clean Up
+
+```bash
+agr instance delete "$instance_id" --ignore-not-found -o json
+agr tool delete "$tool_id" -o json || true
+```
+
+Deleting an Instance or Tool does not delete COS objects, CFS data, or registry images.
+
+## Troubleshoot First
+
+```bash
+agr status -o json
+agr doctor -o json
+agr schema -o json
+agr explain AUTH_FAILED -o json
+# Per-flag help
+agr instance create --network-configuration --help
+# Debug output to stderr
+agr instance list -o json --debug
+```
+
+Useful global flags: `--debug` (verbose stderr), `--non-interactive` (suppress prompts in scripts), `--no-color`, `--region`, `--domain`, `--cloud-endpoint`.
+
+If public docs and the installed CLI disagree, trust `agr --help` / `agr schema -o json` for command syntax and product docs for concept meaning.

--- a/skills/ags/references/advanced-workflows.md
+++ b/skills/ags/references/advanced-workflows.md
@@ -1,0 +1,114 @@
+# Advanced AGR Workflows
+
+Load this file only when the user asks for browser/mobile sandboxes, API keys, raw Cloud API calls, image pre-cache, interactive login, or port access. For custom-image services, read [custom-images.md](custom-images.md).
+
+## Browser
+
+Create a browser Tool and show its VNC URL:
+
+```bash
+browser_tool_id=$(agr tool create \
+  --tool-name "browser-$(date +%s)-$$" \
+  --tool-type browser \
+  --network-configuration '{"NetworkMode":"PUBLIC"}' \
+  -o json --jq '.Data.ToolId')
+
+browser_id=$(agr instance create \
+  --tool-id "$browser_tool_id" \
+  --timeout 30m \
+  -o json --jq '.Data.InstanceId')
+
+agr instance browser vnc "$browser_id" -o json
+```
+
+`browser vnc` returns JSON. Local Playwright/CDP details belong in SDK reference docs only when the user asks for SDK/browser automation code.
+
+## Mobile
+
+Create a mobile Tool and connect ADB to a short-lived Instance:
+
+```bash
+mobile_tool_id=$(agr tool create \
+  --tool-name "mobile-$(date +%s)-$$" \
+  --tool-type mobile \
+  --network-configuration '{"NetworkMode":"PUBLIC"}' \
+  -o json --jq '.Data.ToolId')
+
+mobile_id=$(agr instance create \
+  --tool-id "$mobile_tool_id" \
+  --timeout 30m \
+  -o json --jq '.Data.InstanceId')
+
+agr instance get "$mobile_id" -o json
+agr instance mobile connect "$mobile_id" -o json
+```
+
+After connecting:
+
+```bash
+agr instance mobile connect "$instance_id" -o json
+agr instance mobile list -o json
+agr instance mobile adb "$instance_id" -o json -- shell getprop ro.product.model
+agr instance mobile disconnect "$instance_id" -o json
+agr instance mobile disconnect --all -o json
+agr instance mobile tunnel "$instance_id"  # manage tunnels directly
+```
+
+`mobile adb` requires an active tunnel from `mobile connect`.
+
+## Interactive Proxy And Login
+
+```bash
+agr instance proxy "$instance_id" 3000:8080 --address 127.0.0.1
+agr instance login "$instance_id" --user root
+agr instance login "$instance_id" --mode webshell  # browser-based shell instead of PTY
+```
+
+`--mode` accepts `pty` (default, native terminal) or `webshell` (browser mode).
+
+These commands are interactive and do not support JSON output. Do not run them in unattended scripts unless the user explicitly wants an interactive session.
+
+`instance login` propagates the remote shell exit code (like `ssh`). If the PTY/envd session fails, it now reports the specific failure rather than a generic error.
+
+## API Keys
+
+API keys are for E2B SDK / MCP access, not for Cloud API management:
+
+```bash
+key_id=$(agr apikey create \
+  --name "agent-key-$(date +%s)" \
+  -o json --jq '.Data.KeyId')
+
+agr apikey list -o json
+agr apikey delete "$key_id" -o json
+```
+
+Do not print newly created API key secrets into logs or docs.
+
+## Raw Cloud API
+
+Use typed `agr tool`, `agr instance`, `agr apikey`, and `agr pre-cache-image-task` commands first. Use `agr api call` only when typed commands do not cover the operation.
+
+```bash
+agr api call DescribeSandboxInstanceList --request '{"Limit":1}' -o json
+agr api call DescribeSystemImages --request '{"Keyword":"python","Limit":20}' -o json
+agr api call StartSandboxInstance --request @start.json -o json
+```
+
+Server-side errors now include `RequestId` alongside `Code` and `Message` in CLI output, useful for filing support tickets.
+
+## Image Pre-Cache
+
+```bash
+digest=$(agr pre-cache-image-task create \
+  --image "ccr.ccs.tencentyun.com/team/runtime:v1" \
+  --image-registry-type enterprise \
+  -o json --jq '.Data.ImageDigest')
+
+agr pre-cache-image-task get "$digest" \
+  --image "ccr.ccs.tencentyun.com/team/runtime:v1" \
+  --image-registry-type enterprise \
+  -o json
+```
+
+Supported registry types are `enterprise` and `personal`. Check `agr pre-cache-image-task create --help` before using in automation.

--- a/skills/ags/references/custom-images.md
+++ b/skills/ags/references/custom-images.md
@@ -1,0 +1,174 @@
+# AGR Custom Image Services
+
+Use this for high-frequency service runtime tasks: custom images, long-running HTTP services, explicit ports, probes, resources, env vars, private registries, or per-instance overrides.
+
+Prefer a full request JSON because probes, ports, resources, env, RoleArn, storage mounts, and log configuration are nested:
+
+```bash
+agr tool create --generate-skeleton > tool.json
+agr tool create --request @tool.json -o json
+```
+
+### Minimal HTTP Service Tool
+
+Create `custom-service-tool.json`:
+
+```json
+{
+  "ToolName": "custom-svc-REPLACE",
+  "ToolType": "custom",
+  "Description": "Custom HTTP service runtime",
+  "DefaultTimeout": "1h",
+  "NetworkConfiguration": {
+    "NetworkMode": "PUBLIC"
+  },
+  "CustomConfiguration": {
+    "Image": "ccr.ccs.tencentyun.com/team/app:latest",
+    "ImageRegistryType": "enterprise",
+    "Command": ["/bin/sh"],
+    "Args": ["-c", "python -m uvicorn app:app --host 0.0.0.0 --port 8080"],
+    "Env": [
+      {
+        "Name": "APP_ENV",
+        "Value": "prod"
+      }
+    ],
+    "Ports": [
+      {
+        "Name": "http",
+        "Port": 8080,
+        "Protocol": "TCP"
+      }
+    ],
+    "Probe": {
+      "HttpGet": {
+        "Path": "/health",
+        "Port": 8080,
+        "Scheme": "HTTP"
+      },
+      "ReadyTimeoutMs": 30000,
+      "ProbePeriodMs": 5000,
+      "ProbeTimeoutMs": 3000,
+      "SuccessThreshold": 1,
+      "FailureThreshold": 5
+    },
+    "Resources": {
+      "CPU": "2",
+      "Memory": "4Gi"
+    }
+  },
+  "Tags": [
+    {
+      "Key": "kind",
+      "Value": "custom-service"
+    }
+  ]
+}
+```
+
+Create and verify:
+
+```bash
+tool_id=$(agr tool create \
+  --request @custom-service-tool.json \
+  -o json --jq '.Data.ToolId')
+
+agr tool get "$tool_id" -o json
+
+instance_id=$(agr instance create \
+  --tool-id "$tool_id" \
+  --timeout 30m \
+  --auth-mode TOKEN \
+  -o json --jq '.Data.InstanceId')
+
+agr instance get "$instance_id" -o json
+agr instance exec "$instance_id" -o json -- sh -lc "curl -fsS http://127.0.0.1:8080/health"
+```
+
+If the user wants to inspect the service from the local machine, run an interactive proxy only when requested:
+
+```bash
+agr instance proxy "$instance_id" 3000:8080 --address 127.0.0.1
+```
+
+### Private Registry Or Storage Access
+
+Add `RoleArn` when the image registry or mounts require cloud access:
+
+```json
+{
+  "RoleArn": "qcs::cam::uin/100000000:roleName/ags-runtime-role"
+}
+```
+
+For COS/CFS/Image mounts, combine this custom Tool JSON with `StorageMounts`; see [mount-templates.md](mount-templates.md). Use mount paths that do not collide with the application path.
+
+### Fork A Custom Tool With Overrides
+
+Use this when the user has an existing custom Tool but wants a new image tag, new env vars, changed resources, or changed ports:
+
+```bash
+agr tool get "$source_tool_id" -o json
+```
+
+Create `custom-override.json` with only the custom fields to override:
+
+```json
+{
+  "Image": "ccr.ccs.tencentyun.com/team/app:v2",
+  "ImageRegistryType": "enterprise",
+  "Env": [
+    {
+      "Name": "APP_ENV",
+      "Value": "staging"
+    }
+  ],
+  "Ports": [
+    {
+      "Name": "http",
+      "Port": 8080,
+      "Protocol": "TCP"
+    }
+  ],
+  "Resources": {
+    "CPU": "4",
+    "Memory": "8Gi"
+  }
+}
+```
+
+Fork and verify:
+
+```bash
+new_tool_id=$(agr tool fork "$source_tool_id" \
+  --tool-name "custom-fork-$(date +%s)-$$" \
+  --custom-configuration @custom-override.json \
+  -o json --jq '.Data.ToolId')
+
+agr tool get "$new_tool_id" -o json
+```
+
+### Per-Instance Overrides
+
+Use per-instance overrides for temporary env/image changes that should not become a new Tool:
+
+```bash
+instance_id=$(agr instance create \
+  --tool-id "$tool_id" \
+  --timeout 30m \
+  --custom-configuration '{"Env":[{"Name":"RUN_ID","Value":"test-001"}]}' \
+  -o json --jq '.Data.InstanceId')
+```
+
+### Custom Tool Checklist
+
+- `ToolType: "custom"`
+- `CustomConfiguration.Image`
+- `CustomConfiguration.ImageRegistryType`
+- `CustomConfiguration.Command` / `Args`
+- `CustomConfiguration.Ports`
+- `CustomConfiguration.Probe`
+- `CustomConfiguration.Resources`
+- `RoleArn` for private/personal/enterprise registries or storage mounts
+
+Probe configuration is required for services that must become ready before use. `ReadyTimeoutMs` must be at most `30000`. Validate with `agr tool get <tool-id> -o json`, then start a test Instance, wait for `RUNNING`, and verify the service from inside the Instance before exposing a local proxy.

--- a/skills/ags/references/mount-templates.md
+++ b/skills/ags/references/mount-templates.md
@@ -1,0 +1,184 @@
+# AGS Storage Mount Templates
+
+Use these with `agr tool create --storage-mounts @file.json` or `agr tool create --request @tool.json`. Validate the installed CLI with:
+
+```bash
+agr tool create --help
+agr instance create --help
+agr schema -o json
+```
+
+## COS Mount
+
+`RoleArn` is required for COS access. Bucket names usually include the APPID suffix.
+
+```json
+[
+  {
+    "Name": "cos-assets",
+    "StorageSource": {
+      "Cos": {
+        "BucketName": "team-shared-1250000000",
+        "BucketPath": "/datasets"
+      }
+    },
+    "MountPath": "/mnt/assets",
+    "ReadOnly": false
+  }
+]
+```
+
+```bash
+agr tool create \
+  --tool-name "cos-tool-$(date +%s)-$$" \
+  --tool-type code-interpreter \
+  --network-configuration '{"NetworkMode":"PUBLIC"}' \
+  --role-arn "qcs::cam::uin/100000000:roleName/ags-cos-role" \
+  --storage-mounts @cos-mount.json \
+  -o json
+```
+
+## CFS And Image Mounts
+
+Use `--request` when several nested fields are required.
+
+```json
+{
+  "ToolName": "analysis-runtime",
+  "ToolType": "custom",
+  "NetworkConfiguration": {
+    "NetworkMode": "PUBLIC"
+  },
+  "RoleArn": "qcs::cam::uin/100000000:roleName/ags-storage-role",
+  "StorageMounts": [
+    {
+      "Name": "cfs-workspace",
+      "StorageSource": {
+        "Cfs": {
+          "FileSystemId": "cfs-12345678",
+          "Path": "/team/project-a"
+        }
+      },
+      "MountPath": "/workspace/project-a",
+      "ReadOnly": false
+    },
+    {
+      "Name": "image-seed",
+      "StorageSource": {
+        "Image": {
+          "Reference": "ccr.ccs.tencentyun.com/team/bootstrap:v1",
+          "ImageRegistryType": "CCR",
+          "SubPath": "/seed"
+        }
+      },
+      "MountPath": "/opt/seed",
+      "ReadOnly": true
+    }
+  ]
+}
+```
+
+```bash
+agr tool create --request @tool-storage.json --non-interactive -o json
+```
+
+## Fork Existing Tool And Add CFS
+
+Use this when the user wants a new Tool based on an existing Tool, such as
+"fork `sdt-1234567` and mount CFS `cfs-1234567`".
+
+First inspect the source Tool. Reuse its `RoleArn` if present; otherwise ask the user for the CAM role ARN that can access the CFS filesystem. Current `agr tool update` does not expose a direct `--storage-mounts` flag, so create a new fork instead of mutating the source Tool in place.
+
+```bash
+source_tool_id="sdt-1234567"
+agr tool get "$source_tool_id" -o json
+```
+
+Create a CFS mount file. Choose a mount name and path that do not conflict with existing mounts on the source Tool.
+
+```json
+[
+  {
+    "Name": "cfs-workspace",
+    "StorageSource": {
+      "Cfs": {
+        "FileSystemId": "cfs-1234567",
+        "Path": "/"
+      }
+    },
+    "MountPath": "/workspace/cfs",
+    "ReadOnly": false
+  }
+]
+```
+
+Fork the Tool with the new mount. Include `--role-arn` if the source Tool does not already have an appropriate role or if the mount requires a different role.
+
+```bash
+new_tool_id=$(agr tool fork "$source_tool_id" \
+  --tool-name "fork-cfs-$(date +%s)-$$" \
+  --storage-mounts @cfs-mount.json \
+  -o json --jq '.Data.ToolId')
+
+agr tool get "$new_tool_id" -o json
+```
+
+If a role must be supplied or overridden:
+
+```bash
+new_tool_id=$(agr tool fork "$source_tool_id" \
+  --tool-name "fork-cfs-$(date +%s)-$$" \
+  --role-arn "qcs::cam::uin/100000000:roleName/ags-cfs-role" \
+  --storage-mounts @cfs-mount.json \
+  -o json --jq '.Data.ToolId')
+```
+
+Validate by starting a short-lived Instance and checking the mount path:
+
+```bash
+instance_id=$(agr instance create \
+  --tool-id "$new_tool_id" \
+  --timeout 30m \
+  -o json --jq '.Data.InstanceId')
+
+agr instance get "$instance_id" -o json
+agr instance exec "$instance_id" -o json -- ls -la /workspace/cfs
+agr instance delete "$instance_id" --ignore-not-found -o json
+```
+
+## Instance MountOptions
+
+`MountOptions` can only reference names already defined in Tool `StorageMounts`.
+
+```json
+[
+  {
+    "Name": "cos-assets",
+    "MountPath": "/workspace/input",
+    "SubPath": "run-001",
+    "ReadOnly": true
+  },
+  {
+    "Name": "cos-assets",
+    "MountPath": "/workspace/output",
+    "SubPath": "run-002",
+    "ReadOnly": false
+  }
+]
+```
+
+```bash
+agr instance create \
+  --tool-id "$tool_id" \
+  --mount-options @mount-options.json \
+  --timeout 30m \
+  -o json
+```
+
+## Path Rules
+
+- `MountPath` must be absolute, cannot be `/`, cannot contain `.` or `..`, and cannot duplicate another resolved mount path.
+- `SubPath` must be relative, cannot start with `/`, and cannot contain `.` or `..`.
+- `mobile` and `android-world` mount under `/data/local/tmp/mnt`.
+- `osworld` mounts under `/tmp/mnt`.
+- For other Tool types, avoid system paths such as `/bin`, `/etc`, `/tmp`, `/usr`, `/var`; use subdirectories under `/workspace`, `/mnt`, `/home`, or `/data`.

--- a/skills/ags/references/troubleshooting.md
+++ b/skills/ags/references/troubleshooting.md
@@ -1,0 +1,111 @@
+# AGR Troubleshooting Reference
+
+Load this file when an `agr` command fails, an Instance is not usable, resource cleanup fails, or docs disagree with the installed CLI.
+
+## Diagnostic Commands
+
+```bash
+agr version -o json
+agr status -o json
+agr doctor -o json
+agr schema -o json
+agr explain <CODE> -o json
+# Per-flag help
+agr <command> --<flag> --help
+```
+
+Use `agr <path> --help` for exact command syntax. Treat installed CLI help/schema as authoritative for flags.
+
+## JSON Failure Handling
+
+Most JSON commands return an `agr.v1` envelope:
+
+```json
+{
+  "SchemaVersion": "agr.v1",
+  "Command": "tool.list",
+  "Status": "failed",
+  "Data": null,
+  "Failure": {
+    "Code": "MISSING_CLOUD_CREDENTIALS",
+    "Kind": "auth",
+    "Message": "cloud API credentials are required",
+    "Hint": "Run: agr init --secret-id <id> --secret-key <key>",
+    "Retryable": false
+  },
+  "Warnings": [],
+  "Meta": {}
+}
+```
+
+Check `.Failure.Code` and `.Failure.Hint` before guessing. Server-side errors now also include `RequestId` for support tickets.
+
+## Common Issues
+
+| Symptom | Checks |
+| --- | --- |
+| Missing credentials | `agr status -o json`, then configure `TENCENTCLOUD_SECRET_ID` / `TENCENTCLOUD_SECRET_KEY` with `agr init`. |
+| Auth failure | `agr doctor -o json`, `agr explain AUTH_FAILED -o json`, verify CAM permissions, region, and STS token expiry. |
+| Unknown command or flag | `agr version -o json`, `agr <command> --help`, `agr schema -o json`. Use `--<flag> --help` for per-flag details. |
+| `--jq` does not work | Ensure the command also has `-o json`. |
+| Streaming command fails with JSON | Use `--stream -o ndjson` or plain text, not `--stream -o json`. |
+| Instance not ready | `agr instance get <id> -o json`; wait for `RUNNING`. |
+| Tool delete fails | Delete active Instances created from the Tool first. |
+| Network issue | Check `NetworkConfiguration`, `--region`, `--domain`, `--cloud-endpoint`, proxy, and VPC fields. |
+| Mount issue | Check `StorageMounts`, `MountOptions`, RoleArn, path rules, COS bucket APPID suffix, CFS region/mount availability. |
+| `instance debug` flag error | JSON flags (`--mount-options`, `--metadata`, `--custom-configuration`) support `@file` and `-` (stdin). Invalid JSON now shows `INVALID_JSON_FLAG` with a clear hint. |
+| `instance login` shows a generic error | Upgrade to the latest `agr` — recent versions report the specific PTY/envd failure instead of a generic error. |
+
+## Instance Status Values
+
+Instance responses may include these status values. Some command help text may list only a subset of status filter values; check `agr instance list --help` / `agr schema -o json` before using status filters in automation.
+
+| Status | Meaning |
+| --- | --- |
+| `STARTING` | Creation accepted, not yet ready. |
+| `RUNNING` | Stable and usable. |
+| `FAILED` | Terminal failed state; inspect returned failure details. |
+| `STOPPING` / `STOPPED` | Ending / ended. Cannot continue the same session after stopped. |
+| `STARTING_FAILED` | Creation failed before the Instance became usable. |
+| `STOPPING_FAILED` | Stop failed; inspect returned failure details and retry cleanup if appropriate. |
+| `PAUSED` | Paused and not currently usable for normal work; resume before operations that require a running instance. |
+| `PAUSE_FAILED` | Pause operation failed; inspect returned failure details. |
+| `RESUME_FAILED` | Resume operation failed; inspect returned failure details. |
+
+Only `RUNNING` is safe for code, shell, file, browser/mobile, or port operations.
+
+## Exit Codes
+
+| Exit Code | Type | Description |
+| ---: | --- | --- |
+| 0 | `success` | Command succeeded. |
+| 1 | `error` | Non-usage, non-auth CLI or API failure; check `Failure.Kind`. |
+| 2 | `usage` | Invalid arguments, flags, input, or unsupported output mode. |
+| 4 | `auth` | Missing credentials, auth failure, or insufficient permissions. |
+| 255 | `remote_execution_failed` | Remote code execution failed. |
+
+`instance exec` and `instance mobile adb` may also pass through downstream process exit codes (0–255).
+
+Full list: `agr schema -o json --jq '.Data.ExitCodes'`.
+
+## Cleanup
+
+```bash
+agr instance list --tool-id "$tool_id" -o json
+agr instance list --all -o json          # All instances, paginated, with region info
+agr instance delete "$instance_id" --ignore-not-found -o json
+agr tool delete "$tool_id" -o json
+```
+
+If `tool delete` fails with a resource-in-use style error, list and delete related Instances first.
+
+Deleting AGS resources does not delete external COS objects, CFS filesystems, or registry images.
+
+## CLI Drift Rules
+
+If cookbook docs and the installed `agr` disagree:
+
+1. Use installed `agr --help` / `agr schema -o json` for command names and flags.
+2. Use product docs for concept meaning and service constraints.
+3. Mention the discrepancy in the user response if it affects reliability.
+4. Prefer conservative commands that avoid creating/deleting resources until confirmed.

--- a/skills/ags/references/vpc-networking.md
+++ b/skills/ags/references/vpc-networking.md
@@ -1,0 +1,142 @@
+# AGR VPC Networking
+
+Load this file when the user asks for private network access, VPC mode, subnet/security group configuration, private services, databases, Redis, private APIs, or a new Tool with different network access.
+
+## Required Inputs
+
+Ask for any missing required values before creating VPC resources:
+
+- `SubnetIds`: one or more subnet IDs, for example `subnet-xxxx`.
+- `SecurityGroupIds`: one or more security group IDs, for example `sg-xxxx`.
+- Region: use `agr status -o json` to inspect the resolved region, or pass `--region`.
+- Target private endpoint to verify, such as a private HTTP URL, database host/port, or Redis host/port.
+
+VPC mode does not use public Internet routing by default. Security group and subnet routing rules must allow the intended outbound traffic from the sandbox.
+
+## Create A VPC Code Tool
+
+```bash
+network_config='{
+  "NetworkMode": "VPC",
+  "VpcConfig": {
+    "SubnetIds": ["subnet-xxxx"],
+    "SecurityGroupIds": ["sg-xxxx"]
+  }
+}'
+
+tool_id=$(agr tool create \
+  --tool-name "vpc-code-$(date +%s)-$$" \
+  --tool-type code-interpreter \
+  --network-configuration "$network_config" \
+  --default-timeout 1h \
+  -o json --jq '.Data.ToolId')
+
+agr tool get "$tool_id" -o json
+```
+
+## Create A VPC Custom Service Tool
+
+Use a full request when combining VPC mode with a custom image, ports, probes, resources, RoleArn, or storage mounts.
+
+```json
+{
+  "ToolName": "vpc-custom-svc-REPLACE",
+  "ToolType": "custom",
+  "Description": "Custom service with VPC network access",
+  "DefaultTimeout": "1h",
+  "NetworkConfiguration": {
+    "NetworkMode": "VPC",
+    "VpcConfig": {
+      "SubnetIds": ["subnet-xxxx"],
+      "SecurityGroupIds": ["sg-xxxx"]
+    }
+  },
+  "CustomConfiguration": {
+    "Image": "ccr.ccs.tencentyun.com/team/app:latest",
+    "ImageRegistryType": "enterprise",
+    "Command": ["/bin/sh"],
+    "Args": ["-c", "python -m uvicorn app:app --host 0.0.0.0 --port 8080"],
+    "Ports": [
+      {
+        "Name": "http",
+        "Port": 8080,
+        "Protocol": "TCP"
+      }
+    ],
+    "Probe": {
+      "HttpGet": {
+        "Path": "/health",
+        "Port": 8080,
+        "Scheme": "HTTP"
+      },
+      "ReadyTimeoutMs": 30000,
+      "ProbePeriodMs": 5000,
+      "ProbeTimeoutMs": 3000,
+      "SuccessThreshold": 1,
+      "FailureThreshold": 5
+    },
+    "Resources": {
+      "CPU": "2",
+      "Memory": "4Gi"
+    }
+  }
+}
+```
+
+```bash
+tool_id=$(agr tool create \
+  --request @vpc-custom-tool.json \
+  -o json --jq '.Data.ToolId')
+
+agr tool get "$tool_id" -o json
+```
+
+For private registries or storage mounts, add `RoleArn`; see [custom-images.md](custom-images.md) for custom-image service details and [mount-templates.md](mount-templates.md) for mount JSON.
+`ReadyTimeoutMs` must be at most `30000`.
+
+## Fork Existing Tool Into VPC
+
+Use this when the user wants the same Tool settings with VPC network access. VPC network configuration is creation-time only; do not try to update an existing Tool's network mode in place.
+
+```bash
+source_tool_id="sdt-xxxx"
+agr tool get "$source_tool_id" -o json
+
+new_tool_id=$(agr tool fork "$source_tool_id" \
+  --tool-name "vpc-fork-$(date +%s)-$$" \
+  --network-configuration '{
+    "NetworkMode": "VPC",
+    "VpcConfig": {
+      "SubnetIds": ["subnet-xxxx"],
+      "SecurityGroupIds": ["sg-xxxx"]
+    }
+  }' \
+  -o json --jq '.Data.ToolId')
+
+agr tool get "$new_tool_id" -o json
+```
+
+Do not mutate an existing Tool's network configuration. To move a workload between `SANDBOX`, `PUBLIC`, and `VPC`, create or fork a new Tool with the desired `NetworkConfiguration`.
+
+## Validate Private Access
+
+Create a short-lived Instance, wait for `RUNNING`, then verify the specific private target:
+
+```bash
+instance_id=$(agr instance create \
+  --tool-id "$tool_id" \
+  --timeout 30m \
+  -o json --jq '.Data.InstanceId')
+
+agr instance get "$instance_id" -o json
+
+# Private HTTP service
+agr instance exec "$instance_id" -o json -- sh -lc "curl -fsS http://10.0.0.10:8080/health"
+
+# TCP port check
+agr instance exec "$instance_id" -o json -- sh -lc "nc -vz 10.0.0.10 6379"
+
+agr instance delete "$instance_id" --ignore-not-found -o json
+```
+
+If validation fails, check region, subnet route tables, security group egress/ingress, private DNS, and whether the target service allows traffic from the selected subnet/security group.


### PR DESCRIPTION
## Summary

Adds an AGS reference Agent Skill example under `skills/ags`.

The Skill demonstrates CLI-first AGS workflows with `agr`, using progressive disclosure so the main `SKILL.md` stays focused while detailed scenario guidance lives in reference files.

## Changes

- Add `skills/ags/SKILL.md` with core AGS workflows:
  - CLI setup and credential checks
  - Tool and Instance creation
  - code/shell execution
  - file transfer
  - debug instances
  - cleanup and troubleshooting entry points

- Add reference docs for focused AGS scenarios:
  - storage mounts: COS/CFS/Image mount templates
  - custom-image services: ports, probes, resources, env, registry access
  - VPC networking: create/fork VPC Tools and validate private access
  - advanced workflows: browser/mobile/API keys/raw API/image pre-cache/login/proxy
  - troubleshooting: failure handling, status values, cleanup, CLI drift

- Update root README and `skills/README.md` to introduce the AGS reference Agent Skill example and its progressive disclosure structure.