### PR TITLE
fix(examples/osworld-ags): Fix OSWorld AGS sandbox reset and CDP bridge

### DIFF
--- a/examples/osworld-ags/Makefile
+++ b/examples/osworld-ags/Makefile
@@ -8,7 +8,7 @@ OSWORLD_PY := $(OSWORLD_VENV)/bin/python
 setup:
 	@test -d $(OSWORLD_DIR) || (echo "missing $(OSWORLD_DIR): clone OSWorld first" && exit 1)
 	uv python install $(OSWORLD_PYTHON)
-	uv venv --python $(OSWORLD_PYTHON) $(OSWORLD_VENV)
+	@test -x $(OSWORLD_PY) || uv venv --python $(OSWORLD_PYTHON) $(OSWORLD_VENV)
 	cd $(OSWORLD_DIR) && uv pip install --python .venv/bin/python -r requirements.txt
 
 run:

--- a/examples/osworld-ags/README.md
+++ b/examples/osworld-ags/README.md
@@ -8,6 +8,7 @@ It works by copying a small overlay into a local OSWorld checkout. The overlay a
 
 - `provider_name=ags` support in OSWorld
 - local HTTP/WebSocket proxying for AGS sandbox access
+- a VM-side Chrome CDP bridge that uses only the Python standard library
 - noVNC support for remote desktop viewing
 
 ## Before You Start
@@ -62,7 +63,7 @@ Note: currently only supports Python 3.10
 make setup
 ```
 
-This creates `osworld/.venv` with `uv`, installs Python 3.10 if needed, and installs the overlaid `requirements.txt` into that virtual environment. The overlay adds the AGS dependencies to `requirements.txt`, including `e2b-code-interpreter` and `aiohttp`.
+This creates `osworld/.venv` with `uv`, installs Python 3.10 if needed, and installs the overlaid `requirements.txt` into that virtual environment. The overlay includes the AGS dependencies, including `e2b`, `e2b-code-interpreter`, and `aiohttp`. It pins `e2b` to an AGS-compatible range because newer upstream SDK releases validate only `e2b_...` keys, while AGS API keys commonly use the `ark_...` form.
 
 ## Run
 
@@ -87,6 +88,7 @@ New files added to OSWorld:
 
 - `desktop_env/providers/ags/__init__.py`
 - `desktop_env/providers/ags/config.py`
+- `desktop_env/providers/ags/cdp_proxy.py`
 - `desktop_env/providers/ags/manager.py`
 - `desktop_env/providers/ags/provider.py`
 
@@ -94,7 +96,6 @@ Existing OSWorld files replaced by the overlay:
 
 - `desktop_env/desktop_env.py`
 - `desktop_env/providers/__init__.py`
-- `desktop_env/controllers/python.py`
 - `run_multienv.py`
 - `requirements.txt`
 
@@ -111,4 +112,7 @@ http://localhost:<vnc_port>/vnc.html
 - This is not an official upstream OSWorld release.
 - The AGS provider is distributed here as a cookbook overlay.
 - The overlaid source is derived from OSWorld and remains under Apache-2.0.
+- AGS does not expose VM snapshots through the OSWorld provider. The overlay
+  treats OSWorld snapshot revert as "replace the sandbox" to avoid leaking the
+  previous sandbox between tasks.
 - Upstream project: [xlang-ai/OSWorld](https://github.com/xlang-ai/OSWorld)

--- a/examples/osworld-ags/README.md
+++ b/examples/osworld-ags/README.md
@@ -62,7 +62,7 @@ Note: currently only supports Python 3.10
 make setup
 ```
 
-This creates `osworld/.venv` with `uv`, installs Python 3.10 if needed, and installs the overlaid `requirements.txt` into that virtual environment. The overlay includes the AGS dependencies, including `e2b`, `e2b-code-interpreter`, and `aiohttp`. If your AGS API key starts with `ark_` and the SDK validates for an `e2b_` prefix, replace only the prefix with `e2b_`; the key-format check does not require downgrading the SDK.
+This creates `osworld/.venv` with `uv`, installs Python 3.10 if needed, and installs the overlaid `requirements.txt` into that virtual environment. The overlay includes the AGS dependencies, including `e2b`, `e2b-code-interpreter`, and `aiohttp`. These SDK versions are capped so AGS API keys that start with `ark_` work without extra changes. If you manually upgrade to a newer SDK that validates for an `e2b_` prefix, replace only the key prefix with `e2b_`.
 
 ## Run
 

--- a/examples/osworld-ags/README.md
+++ b/examples/osworld-ags/README.md
@@ -8,7 +8,6 @@ It works by copying a small overlay into a local OSWorld checkout. The overlay a
 
 - `provider_name=ags` support in OSWorld
 - local HTTP/WebSocket proxying for AGS sandbox access
-- a VM-side Chrome CDP bridge that uses only the Python standard library
 - noVNC support for remote desktop viewing
 
 ## Before You Start
@@ -63,7 +62,7 @@ Note: currently only supports Python 3.10
 make setup
 ```
 
-This creates `osworld/.venv` with `uv`, installs Python 3.10 if needed, and installs the overlaid `requirements.txt` into that virtual environment. The overlay includes the AGS dependencies, including `e2b`, `e2b-code-interpreter`, and `aiohttp`. It pins `e2b` to an AGS-compatible range because newer upstream SDK releases validate only `e2b_...` keys, while AGS API keys commonly use the `ark_...` form.
+This creates `osworld/.venv` with `uv`, installs Python 3.10 if needed, and installs the overlaid `requirements.txt` into that virtual environment. The overlay includes the AGS dependencies, including `e2b`, `e2b-code-interpreter`, and `aiohttp`. If your AGS API key starts with `ark_` and the SDK validates for an `e2b_` prefix, replace only the prefix with `e2b_`; the key-format check does not require downgrading the SDK.
 
 ## Run
 
@@ -115,4 +114,7 @@ http://localhost:<vnc_port>/vnc.html
 - AGS does not expose VM snapshots through the OSWorld provider. The overlay
   treats OSWorld snapshot revert as "replace the sandbox" to avoid leaking the
   previous sandbox between tasks.
+- The provider authenticates sandbox traffic with the sandbox access token by
+  default; it does not require `e2b-traffic-access-token` for normal OSWorld
+  runs.
 - Upstream project: [xlang-ai/OSWorld](https://github.com/xlang-ai/OSWorld)

--- a/examples/osworld-ags/README_zh.md
+++ b/examples/osworld-ags/README_zh.md
@@ -8,6 +8,7 @@
 
 - OSWorld 中可直接使用 `provider_name=ags`
 - 面向 AGS 的本地 HTTP/WebSocket 代理
+- VM 内只依赖 Python 标准库的 Chrome CDP bridge
 - 用于远程桌面观察的 noVNC 支持
 
 ## 开始前需要准备
@@ -62,7 +63,7 @@ OPENAI_BASE_URL=https://api.openai.com/v1
 make setup
 ```
 
-这会用 `uv` 创建 `osworld/.venv`，按需安装 Python 3.10，并把 overlay 后的 `requirements.txt` 安装到该虚拟环境中。overlay 会把 AGS 依赖写入 `requirements.txt`，包括 `e2b-code-interpreter` 和 `aiohttp`。
+这会用 `uv` 创建 `osworld/.venv`，按需安装 Python 3.10，并把 overlay 后的 `requirements.txt` 安装到该虚拟环境中。overlay 会加入 AGS 依赖，包括 `e2b`、`e2b-code-interpreter` 和 `aiohttp`。其中 `e2b` 会固定在 AGS 兼容的版本范围，因为较新的上游 SDK 只接受 `e2b_...` 格式的 key，而 AGS API Key 常见格式是 `ark_...`。
 
 ## 运行
 
@@ -87,6 +88,7 @@ uv run --python .venv/bin/python run_multienv.py --provider_name ags --model gpt
 
 - `desktop_env/providers/ags/__init__.py`
 - `desktop_env/providers/ags/config.py`
+- `desktop_env/providers/ags/cdp_proxy.py`
 - `desktop_env/providers/ags/manager.py`
 - `desktop_env/providers/ags/provider.py`
 
@@ -94,7 +96,6 @@ uv run --python .venv/bin/python run_multienv.py --provider_name ags --model gpt
 
 - `desktop_env/desktop_env.py`
 - `desktop_env/providers/__init__.py`
-- `desktop_env/controllers/python.py`
 - `run_multienv.py`
 - `requirements.txt`
 
@@ -111,4 +112,5 @@ http://localhost:<vnc_port>/vnc.html
 - 这不是 OSWorld 上游官方发行版。
 - AGS provider 以 cookbook overlay 的形式在这里分发。
 - overlay 中的相关源码派生自 OSWorld，继续遵循 Apache-2.0。
+- AGS provider 不暴露 OSWorld VM snapshot 能力。overlay 会把 snapshot revert 当作“替换一个新 sandbox”，避免多个任务之间泄漏旧 sandbox。
 - 上游项目：[xlang-ai/OSWorld](https://github.com/xlang-ai/OSWorld)

--- a/examples/osworld-ags/README_zh.md
+++ b/examples/osworld-ags/README_zh.md
@@ -62,7 +62,7 @@ OPENAI_BASE_URL=https://api.openai.com/v1
 make setup
 ```
 
-这会用 `uv` 创建 `osworld/.venv`，按需安装 Python 3.10，并把 overlay 后的 `requirements.txt` 安装到该虚拟环境中。overlay 会加入 AGS 依赖，包括 `e2b`、`e2b-code-interpreter` 和 `aiohttp`。如果 AGS API Key 以 `ark_` 开头，且 SDK 校验要求 `e2b_` 前缀，可以只把前缀替换成 `e2b_`；不需要为了 key 格式降级 SDK。
+这会用 `uv` 创建 `osworld/.venv`，按需安装 Python 3.10，并把 overlay 后的 `requirements.txt` 安装到该虚拟环境中。overlay 会加入 AGS 依赖，包括 `e2b`、`e2b-code-interpreter` 和 `aiohttp`。这里会限制 SDK 小版本，让 `ark_` 前缀的 AGS API Key 默认可直接使用。如果你手动升级到更高版本 SDK，且 SDK 校验要求 `e2b_` 前缀，可以只把 key 前缀替换成 `e2b_`。
 
 ## 运行
 

--- a/examples/osworld-ags/README_zh.md
+++ b/examples/osworld-ags/README_zh.md
@@ -8,7 +8,6 @@
 
 - OSWorld 中可直接使用 `provider_name=ags`
 - 面向 AGS 的本地 HTTP/WebSocket 代理
-- VM 内只依赖 Python 标准库的 Chrome CDP bridge
 - 用于远程桌面观察的 noVNC 支持
 
 ## 开始前需要准备
@@ -63,7 +62,7 @@ OPENAI_BASE_URL=https://api.openai.com/v1
 make setup
 ```
 
-这会用 `uv` 创建 `osworld/.venv`，按需安装 Python 3.10，并把 overlay 后的 `requirements.txt` 安装到该虚拟环境中。overlay 会加入 AGS 依赖，包括 `e2b`、`e2b-code-interpreter` 和 `aiohttp`。其中 `e2b` 会固定在 AGS 兼容的版本范围，因为较新的上游 SDK 只接受 `e2b_...` 格式的 key，而 AGS API Key 常见格式是 `ark_...`。
+这会用 `uv` 创建 `osworld/.venv`，按需安装 Python 3.10，并把 overlay 后的 `requirements.txt` 安装到该虚拟环境中。overlay 会加入 AGS 依赖，包括 `e2b`、`e2b-code-interpreter` 和 `aiohttp`。如果 AGS API Key 以 `ark_` 开头，且 SDK 校验要求 `e2b_` 前缀，可以只把前缀替换成 `e2b_`；不需要为了 key 格式降级 SDK。
 
 ## 运行
 
@@ -113,4 +112,5 @@ http://localhost:<vnc_port>/vnc.html
 - AGS provider 以 cookbook overlay 的形式在这里分发。
 - overlay 中的相关源码派生自 OSWorld，继续遵循 Apache-2.0。
 - AGS provider 不暴露 OSWorld VM snapshot 能力。overlay 会把 snapshot revert 当作“替换一个新 sandbox”，避免多个任务之间泄漏旧 sandbox。
+- provider 默认使用 sandbox access token 访问 sandbox；正常 OSWorld 运行不需要 `e2b-traffic-access-token`。
 - 上游项目：[xlang-ai/OSWorld](https://github.com/xlang-ai/OSWorld)

--- a/examples/osworld-ags/overlay/OSWorld/desktop_env/desktop_env.py
+++ b/examples/osworld-ags/overlay/OSWorld/desktop_env/desktop_env.py
@@ -323,6 +323,10 @@ class DesktopEnv(gym.Env):
         return self.controller.get_vm_platform()
 
     @property
+    def vm_machine(self):
+        return self.controller.get_vm_machine()
+
+    @property
     def vm_screen_size(self):
         return self.controller.get_vm_screen_size()
 

--- a/examples/osworld-ags/overlay/OSWorld/desktop_env/providers/ags/cdp_proxy.py
+++ b/examples/osworld-ags/overlay/OSWorld/desktop_env/providers/ags/cdp_proxy.py
@@ -1,0 +1,209 @@
+"""Standard-library Chrome CDP proxy deployed inside the AGS sandbox."""
+
+import json
+import re
+import select
+import socket
+import socketserver
+import sys
+from urllib.parse import urlparse, urlunparse
+
+CHROME_HOST = "127.0.0.1"
+CHROME_PORT = 1337
+LISTEN_HOST = "0.0.0.0"
+LISTEN_PORT = 9222
+BUFFER_SIZE = 65536
+
+
+def log(message):
+    print(message, file=sys.stderr, flush=True)
+
+
+def rewrite_cdp_url(value, local_port=9222):
+    if not isinstance(value, str):
+        return value
+    parsed = urlparse(value)
+    if parsed.scheme in {"ws", "wss"}:
+        return urlunparse(("ws", f"127.0.0.1:{local_port}", parsed.path, "", parsed.query, parsed.fragment))
+    if parsed.scheme in {"http", "https"}:
+        return urlunparse(("http", f"127.0.0.1:{local_port}", parsed.path, "", parsed.query, parsed.fragment))
+    return value
+
+
+def rewrite_cdp_payload(content, local_port=9222):
+    try:
+        payload = json.loads(content.decode("utf-8"))
+    except Exception:
+        content_str = content.decode("utf-8", errors="replace")
+        content_str = re.sub(r"wss?://[^/\\s\"]+:1337", "ws://127.0.0.1:9222", content_str)
+        content_str = content_str.replace(f"localhost:{CHROME_PORT}", "127.0.0.1:9222")
+        return content_str.encode("utf-8")
+
+    def rewrite_item(item):
+        if isinstance(item, dict):
+            rewritten = dict(item)
+            for key in ("webSocketDebuggerUrl", "devtoolsFrontendUrl"):
+                if key in rewritten:
+                    rewritten[key] = rewrite_cdp_url(rewritten[key], local_port)
+            return rewritten
+        return item
+
+    if isinstance(payload, list):
+        payload = [rewrite_item(item) for item in payload]
+    elif isinstance(payload, dict):
+        payload = rewrite_item(payload)
+
+    return json.dumps(payload).encode("utf-8")
+
+
+def recv_until(sock, marker):
+    data = b""
+    while marker not in data:
+        chunk = sock.recv(BUFFER_SIZE)
+        if not chunk:
+            break
+        data += chunk
+    return data
+
+
+def rewrite_host_header(request_bytes):
+    return re.sub(
+        br"(?im)^Host:\s*[^\r\n]+",
+        f"Host: {CHROME_HOST}:{CHROME_PORT}".encode(),
+        request_bytes,
+        count=1,
+    )
+
+
+def parse_request_path(request_bytes):
+    first_line = request_bytes.split(b"\r\n", 1)[0].decode("latin1", errors="replace")
+    parts = first_line.split()
+    return parts[1] if len(parts) >= 2 else "/"
+
+
+def is_websocket_upgrade(request_bytes):
+    return bool(re.search(br"(?im)^Upgrade:\s*websocket\s*$", request_bytes))
+
+
+def read_http_response(sock):
+    data = recv_until(sock, b"\r\n\r\n")
+    if b"\r\n\r\n" not in data:
+        return data
+
+    header_bytes, body = data.split(b"\r\n\r\n", 1)
+    headers = header_bytes.decode("latin1", errors="replace").split("\r\n")
+    content_length = None
+    chunked = False
+    for line in headers[1:]:
+        name, _, value = line.partition(":")
+        if name.lower() == "content-length":
+            try:
+                content_length = int(value.strip())
+            except ValueError:
+                content_length = None
+        elif name.lower() == "transfer-encoding" and "chunked" in value.lower():
+            chunked = True
+
+    if content_length is not None:
+        while len(body) < content_length:
+            chunk = sock.recv(BUFFER_SIZE)
+            if not chunk:
+                break
+            body += chunk
+    elif chunked:
+        while b"\r\n0\r\n\r\n" not in body:
+            chunk = sock.recv(BUFFER_SIZE)
+            if not chunk:
+                break
+            body += chunk
+    else:
+        while True:
+            chunk = sock.recv(BUFFER_SIZE)
+            if not chunk:
+                break
+            body += chunk
+
+    return header_bytes + b"\r\n\r\n" + body
+
+
+def replace_header(header_text, name, value):
+    pattern = re.compile(rf"(?im)^{re.escape(name)}:\s*[^\r\n]*")
+    replacement = f"{name}: {value}"
+    if pattern.search(header_text):
+        return pattern.sub(replacement, header_text, count=1)
+    return header_text + f"\r\n{name}: {value}"
+
+
+def rewrite_http_response(response_bytes, path):
+    if b"\r\n\r\n" not in response_bytes or not path.startswith("/json"):
+        return response_bytes
+    header_bytes, body = response_bytes.split(b"\r\n\r\n", 1)
+    rewritten_body = rewrite_cdp_payload(body, LISTEN_PORT)
+    header_text = header_bytes.decode("latin1", errors="replace")
+    header_text = re.sub(r"(?im)^Transfer-Encoding:\s*chunked\r?\n?", "", header_text)
+    header_text = replace_header(header_text, "Content-Length", str(len(rewritten_body)))
+    return header_text.encode("latin1") + b"\r\n\r\n" + rewritten_body
+
+
+def tunnel(left, right):
+    sockets = [left, right]
+    try:
+        while True:
+            readable, _, _ = select.select(sockets, [], [], 60)
+            if not readable:
+                continue
+            for src in readable:
+                dst = right if src is left else left
+                data = src.recv(BUFFER_SIZE)
+                if not data:
+                    return
+                dst.sendall(data)
+    finally:
+        for sock in sockets:
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+
+class CDPProxyHandler(socketserver.BaseRequestHandler):
+    def handle(self):
+        request_bytes = recv_until(self.request, b"\r\n\r\n")
+        if not request_bytes:
+            return
+        path = parse_request_path(request_bytes)
+        upstream_request = rewrite_host_header(request_bytes)
+        try:
+            upstream = socket.create_connection((CHROME_HOST, CHROME_PORT), timeout=10)
+        except OSError as exc:
+            log(f"connect chrome failed: {exc}")
+            self.request.sendall(
+                b"HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain\r\nContent-Length: 11\r\n\r\nBad Gateway"
+            )
+            return
+
+        with upstream:
+            upstream.sendall(upstream_request)
+            if is_websocket_upgrade(request_bytes):
+                response = recv_until(upstream, b"\r\n\r\n")
+                self.request.sendall(response)
+                tunnel(self.request, upstream)
+                return
+
+            response = read_http_response(upstream)
+            self.request.sendall(rewrite_http_response(response, path))
+
+
+class ThreadingTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+if __name__ == "__main__":
+    with ThreadingTCPServer((LISTEN_HOST, LISTEN_PORT), CDPProxyHandler) as server:
+        log(f"CDP proxy listening on {LISTEN_HOST}:{LISTEN_PORT}")
+        server.serve_forever()

--- a/examples/osworld-ags/overlay/OSWorld/desktop_env/providers/ags/config.py
+++ b/examples/osworld-ags/overlay/OSWorld/desktop_env/providers/ags/config.py
@@ -13,9 +13,8 @@ Modified and redistributed by Agent Sandbox Cookbook as part of the OSWorld AGS 
 import os
 from dotenv import load_dotenv
 
-# Load the example-local .env file. Override existing shell values so a stale
-# global E2B_API_KEY/E2B_DOMAIN does not silently point this example elsewhere.
-load_dotenv(override=True)
+# Load environment variables from .env file
+load_dotenv()
 
 # API Configuration
 E2B_API_KEY = os.environ.get("E2B_API_KEY", "")

--- a/examples/osworld-ags/overlay/OSWorld/desktop_env/providers/ags/config.py
+++ b/examples/osworld-ags/overlay/OSWorld/desktop_env/providers/ags/config.py
@@ -13,8 +13,9 @@ Modified and redistributed by Agent Sandbox Cookbook as part of the OSWorld AGS 
 import os
 from dotenv import load_dotenv
 
-# Load environment variables from .env file
-load_dotenv()
+# Load the example-local .env file. Override existing shell values so a stale
+# global E2B_API_KEY/E2B_DOMAIN does not silently point this example elsewhere.
+load_dotenv(override=True)
 
 # API Configuration
 E2B_API_KEY = os.environ.get("E2B_API_KEY", "")

--- a/examples/osworld-ags/overlay/OSWorld/desktop_env/providers/ags/provider.py
+++ b/examples/osworld-ags/overlay/OSWorld/desktop_env/providers/ags/provider.py
@@ -4,12 +4,8 @@ Modified and redistributed by Agent Sandbox Cookbook as part of the OSWorld AGS 
 """
 
 import atexit
-import json
 import logging
-import os
 import signal
-import shlex
-import ssl
 import time
 import threading
 import socket
@@ -17,7 +13,6 @@ import re
 import requests
 import weakref
 from pathlib import Path
-from urllib.parse import urlparse, urlunparse
 
 from desktop_env.providers.base import Provider
 from desktop_env.providers.ags.config import (
@@ -39,6 +34,11 @@ if not logger.handlers:
 # Global registry of active AGS providers for cleanup
 _active_providers = weakref.WeakSet()
 _cleanup_done = False
+CDP_PROXY_SOURCE = Path(__file__).with_name("cdp_proxy.py")
+
+
+def _read_cdp_proxy_script() -> str:
+    return CDP_PROXY_SOURCE.read_text(encoding="utf-8")
 
 
 def _cleanup_all_providers():
@@ -94,74 +94,6 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
     logger.warning("aiohttp package not available, CDP proxy will have limited functionality")
 
-if AIOHTTP_AVAILABLE:
-    _PERMISSIVE_SSL = ssl.create_default_context()
-    _PERMISSIVE_SSL.check_hostname = False
-    _PERMISSIVE_SSL.verify_mode = ssl.CERT_NONE
-
-
-def _rewrite_cdp_url(raw: str, local_port: int) -> str:
-    """Rewrite CDP URLs to the local proxy port used by Playwright."""
-    if not isinstance(raw, str):
-        return raw
-    parsed = urlparse(raw)
-    if parsed.scheme in ("ws", "wss"):
-        return urlunparse(("ws", f"127.0.0.1:{local_port}", parsed.path, "", parsed.query, parsed.fragment))
-    if parsed.scheme in ("http", "https"):
-        return urlunparse(("http", f"127.0.0.1:{local_port}", parsed.path, "", parsed.query, parsed.fragment))
-    return raw
-
-
-def _rewrite_cdp_payload(content: bytes, local_port: int) -> bytes:
-    """Rewrite CDP /json responses so WS connections go through the local proxy."""
-    try:
-        payload = json.loads(content.decode("utf-8"))
-    except Exception:
-        content_str = content.decode("utf-8", errors="replace")
-        content_str = re.sub(r"wss?://[^/\s\"]+:\d+", f"ws://127.0.0.1:{local_port}", content_str)
-        return content_str.encode("utf-8")
-
-    def rewrite_item(item):
-        if isinstance(item, dict):
-            rewritten = dict(item)
-            for key in ("webSocketDebuggerUrl", "devtoolsFrontendUrl"):
-                if key in rewritten:
-                    rewritten[key] = _rewrite_cdp_url(rewritten[key], local_port)
-            return rewritten
-        return item
-
-    if isinstance(payload, list):
-        payload = [rewrite_item(item) for item in payload]
-    elif isinstance(payload, dict):
-        payload = rewrite_item(payload)
-
-    return json.dumps(payload).encode("utf-8")
-
-
-CDP_PROXY_SOURCE = Path(__file__).with_name("cdp_proxy.py")
-
-
-def _read_cdp_proxy_script() -> str:
-    return CDP_PROXY_SOURCE.read_text(encoding="utf-8")
-
-SOCAT_WRAPPER_SCRIPT = (
-    '#!/bin/bash\n'
-    'REAL=/usr/bin/socat.real\n'
-    'for arg in "$@"; do\n'
-    '  case "$arg" in\n'
-    '    tcp-listen:9222*)\n'
-    '      nohup python3 /tmp/cdp_proxy.py >/tmp/cdp_proxy.log 2>&1 &\n'
-    '      for i in $(seq 1 50); do\n'
-    "        ss -tlnp 2>/dev/null | grep -q ':9222 ' && exit 0\n"
-    '        sleep 0.2\n'
-    '      done\n'
-    '      exit 0\n'
-    '      ;;\n'
-    '  esac\n'
-    'done\n'
-    'exec "$REAL" "$@"\n'
-)
-
 
 def find_available_port(start_port: int) -> int:
     """Find an available port starting from start_port."""
@@ -206,21 +138,6 @@ def find_and_bind_port(start_port: int, max_retries: int = 100) -> socket.socket
     raise RuntimeError(f"No available port found starting from {start_port}")
 
 
-def _build_auth_headers(
-    envd_access_token: str | None,
-    traffic_access_token: str | None,
-    include_traffic: bool = False,
-) -> dict:
-    headers = {}
-    if envd_access_token:
-        headers["X-Access-Token"] = envd_access_token
-    return headers
-
-
-def _should_retry_with_traffic(status: int | None, traffic_access_token: str | None, include_traffic: bool) -> bool:
-    return False
-
-
 class LocalProxyServer:
     """
     Local proxy server for AGS sandbox, supporting both HTTP and WebSocket.
@@ -229,17 +146,10 @@ class LocalProxyServer:
     This is essential for services like noVNC that use WebSocket (websockify).
     """
 
-    def __init__(
-        self,
-        local_port: int,
-        target_host: str,
-        envd_access_token: str | None,
-        traffic_access_token: str | None,
-    ):
+    def __init__(self, local_port: int, target_host: str, access_token: str):
         self.local_port = local_port
         self.target_host = target_host
-        self.envd_access_token = envd_access_token
-        self.traffic_access_token = traffic_access_token
+        self.access_token = access_token
         self.thread = None
         self.loop = None
         self.runner = None
@@ -296,7 +206,7 @@ class LocalProxyServer:
     async def _start_server(self):
         """Start the aiohttp web server with retry on port conflict."""
         import random
-        app = web.Application(client_max_size=0)
+        app = web.Application()
 
         # Route all requests through our handler
         app.router.add_route('*', '/{path:.*}', self._handle_request)
@@ -342,65 +252,51 @@ class LocalProxyServer:
     async def _handle_http(self, request: web.Request, path: str):
         """Handle HTTP request by proxying to the remote sandbox."""
         target_url = f"https://{self.target_host}{path}"
+        headers = {"X-Access-Token": self.access_token}
+
+        # Forward original headers (except host)
+        for key, value in request.headers.items():
+            if key.lower() not in ("host", "transfer-encoding"):
+                headers[key] = value
+        headers["X-Access-Token"] = self.access_token
+
         body = await request.read()
 
         logger.debug("Proxy HTTP %s: %s -> %s", request.method, path, target_url)
 
         try:
             async with aiohttp.ClientSession() as session:
-                for include_traffic in (False, True):
-                    headers = _build_auth_headers(
-                        self.envd_access_token,
-                        self.traffic_access_token,
-                        include_traffic=include_traffic,
-                    )
+                async with session.request(
+                    request.method,
+                    target_url,
+                    headers=headers,
+                    data=body if body else None,
+                    timeout=aiohttp.ClientTimeout(total=300, connect=30),
+                ) as response:
+                    content = await response.read()
 
-                    # Forward original headers (except hop-by-hop and auth headers).
-                    for key, value in request.headers.items():
-                        if key.lower() not in (
-                            "host",
-                            "transfer-encoding",
-                            "x-access-token",
-                            "e2b-traffic-access-token",
-                        ):
-                            headers[key] = value
-
-                    async with session.request(
-                        request.method,
-                        target_url,
-                        headers=headers,
-                        data=body if body else None,
-                        timeout=aiohttp.ClientTimeout(total=300, connect=30),
-                        ssl=_PERMISSIVE_SSL,
-                    ) as response:
-                        content = await response.read()
-
-                        if _should_retry_with_traffic(response.status, self.traffic_access_token, include_traffic):
-                            logger.debug("Retrying %s with traffic token after %d", path, response.status)
-                            continue
-
-                        if response.status >= 500:
-                            logger.warning(
-                                "Remote returned error %d for %s: %s",
-                                response.status, path,
-                                content.decode('utf-8', errors='replace')[:500]
-                            )
-                        elif response.status >= 400:
-                            logger.debug(
-                                "Remote returned %d for %s",
-                                response.status, path,
-                            )
-
-                        resp_headers = {}
-                        for key, value in response.headers.items():
-                            if key.lower() not in ("transfer-encoding", "content-encoding", "content-length"):
-                                resp_headers[key] = value
-
-                        return web.Response(
-                            body=content,
-                            status=response.status,
-                            headers=resp_headers,
+                    if response.status >= 500:
+                        logger.warning(
+                            "Remote returned error %d for %s: %s",
+                            response.status, path,
+                            content.decode('utf-8', errors='replace')[:500]
                         )
+                    elif response.status >= 400:
+                        logger.debug(
+                            "Remote returned %d for %s",
+                            response.status, path,
+                        )
+
+                    resp_headers = {}
+                    for key, value in response.headers.items():
+                        if key.lower() not in ("transfer-encoding", "content-encoding", "content-length"):
+                            resp_headers[key] = value
+
+                    return web.Response(
+                        body=content,
+                        status=response.status,
+                        headers=resp_headers,
+                    )
         except Exception as e:
             logger.error("Proxy HTTP error for %s: %s", path, e)
             return web.Response(text=str(e), status=502)
@@ -411,54 +307,42 @@ class LocalProxyServer:
         await ws_client.prepare(request)
 
         remote_url = f"wss://{self.target_host}{path}"
+        headers = {"X-Access-Token": self.access_token}
 
         logger.debug("Proxy WebSocket: %s -> %s", path, remote_url)
 
         try:
             async with aiohttp.ClientSession() as session:
-                for include_traffic in (False, True):
-                    headers = _build_auth_headers(
-                        self.envd_access_token,
-                        self.traffic_access_token,
-                        include_traffic=include_traffic,
+                async with session.ws_connect(remote_url, headers=headers) as ws_remote:
+                    async def forward_client_to_remote():
+                        try:
+                            async for msg in ws_client:
+                                if msg.type == aiohttp.WSMsgType.TEXT:
+                                    await ws_remote.send_str(msg.data)
+                                elif msg.type == aiohttp.WSMsgType.BINARY:
+                                    await ws_remote.send_bytes(msg.data)
+                                elif msg.type == aiohttp.WSMsgType.CLOSE:
+                                    break
+                        except Exception as e:
+                            logger.debug("Client->Remote forward ended: %s", e)
+
+                    async def forward_remote_to_client():
+                        try:
+                            async for msg in ws_remote:
+                                if msg.type == aiohttp.WSMsgType.TEXT:
+                                    await ws_client.send_str(msg.data)
+                                elif msg.type == aiohttp.WSMsgType.BINARY:
+                                    await ws_client.send_bytes(msg.data)
+                                elif msg.type == aiohttp.WSMsgType.CLOSE:
+                                    break
+                        except Exception as e:
+                            logger.debug("Remote->Client forward ended: %s", e)
+
+                    await asyncio.gather(
+                        forward_client_to_remote(),
+                        forward_remote_to_client(),
+                        return_exceptions=True,
                     )
-                    try:
-                        async with session.ws_connect(remote_url, headers=headers, ssl=_PERMISSIVE_SSL) as ws_remote:
-                            async def forward_client_to_remote():
-                                try:
-                                    async for msg in ws_client:
-                                        if msg.type == aiohttp.WSMsgType.TEXT:
-                                            await ws_remote.send_str(msg.data)
-                                        elif msg.type == aiohttp.WSMsgType.BINARY:
-                                            await ws_remote.send_bytes(msg.data)
-                                        elif msg.type == aiohttp.WSMsgType.CLOSE:
-                                            break
-                                except Exception as e:
-                                    logger.debug("Client->Remote forward ended: %s", e)
-
-                            async def forward_remote_to_client():
-                                try:
-                                    async for msg in ws_remote:
-                                        if msg.type == aiohttp.WSMsgType.TEXT:
-                                            await ws_client.send_str(msg.data)
-                                        elif msg.type == aiohttp.WSMsgType.BINARY:
-                                            await ws_client.send_bytes(msg.data)
-                                        elif msg.type == aiohttp.WSMsgType.CLOSE:
-                                            break
-                                except Exception as e:
-                                    logger.debug("Remote->Client forward ended: %s", e)
-
-                            await asyncio.gather(
-                                forward_client_to_remote(),
-                                forward_remote_to_client(),
-                                return_exceptions=True,
-                            )
-                        break
-                    except aiohttp.WSServerHandshakeError as e:
-                        if _should_retry_with_traffic(e.status, self.traffic_access_token, include_traffic):
-                            logger.debug("Retrying WebSocket %s with traffic token after %d", path, e.status)
-                            continue
-                        raise
 
         except Exception as e:
             logger.error("Proxy WebSocket error: %s", e)
@@ -519,17 +403,10 @@ class CDPProxyServer:
     Uses aiohttp to handle both HTTP requests and WebSocket connections on the same port.
     """
 
-    def __init__(
-        self,
-        local_port: int,
-        target_host: str,
-        envd_access_token: str | None,
-        traffic_access_token: str | None,
-    ):
+    def __init__(self, local_port: int, target_host: str, access_token: str):
         self.local_port = local_port
         self.target_host = target_host
-        self.envd_access_token = envd_access_token
-        self.traffic_access_token = traffic_access_token
+        self.access_token = access_token
         self.thread = None
         self.loop = None
         self.runner = None
@@ -586,7 +463,7 @@ class CDPProxyServer:
     async def _start_server(self):
         """Start the aiohttp web server with retry on port conflict."""
         import random
-        app = web.Application(client_max_size=0)
+        app = web.Application()
 
         # Route all requests through our handler
         app.router.add_route('*', '/{path:.*}', self._handle_request)
@@ -635,39 +512,41 @@ class CDPProxyServer:
     async def _handle_http(self, request: web.Request, path: str):
         """Handle HTTP request."""
         target_url = f"https://{self.target_host}{path}"
+        # Note: Host header is handled by the internal proxy in the sandbox
+        headers = {"X-Access-Token": self.access_token}
 
         logger.debug("CDP HTTP: %s -> %s", path, target_url)
 
         try:
             async with aiohttp.ClientSession() as session:
-                for include_traffic in (False, True):
-                    # Note: Host header is handled by the internal proxy in the sandbox.
-                    headers = _build_auth_headers(
-                        self.envd_access_token,
-                        self.traffic_access_token,
-                        include_traffic=include_traffic,
-                    )
-                    async with session.get(target_url, headers=headers, ssl=_PERMISSIVE_SSL) as response:
-                        content = await response.read()
+                async with session.get(target_url, headers=headers) as response:
+                    content = await response.read()
 
-                        if _should_retry_with_traffic(response.status, self.traffic_access_token, include_traffic):
-                            logger.debug("Retrying CDP HTTP %s with traffic token after %d", path, response.status)
-                            continue
+                    # If remote returns error, log it clearly
+                    if response.status >= 400:
+                        logger.error("Remote CDP returned error %d: %s",
+                                   response.status, content.decode('utf-8', errors='replace')[:500])
 
-                        # If remote returns error, log it clearly
-                        if response.status >= 400:
-                            logger.error("Remote CDP returned error %d: %s",
-                                       response.status, content.decode('utf-8', errors='replace')[:500])
+                    # Rewrite WebSocket URLs in /json/* responses
+                    if path.startswith("/json") and response.status == 200:
+                        content_str = content.decode("utf-8")
+                        logger.debug("CDP /json response: %s", content_str[:200])
 
-                        # Rewrite WebSocket URLs in /json/* responses
-                        if path.startswith("/json") and response.status == 200:
-                            content = _rewrite_cdp_payload(content, self.local_port)
-
-                        return web.Response(
-                            body=content,
-                            status=response.status,
-                            content_type=response.content_type
+                        # Replace remote WebSocket URLs with local
+                        # Pattern matches wss://host or ws://host followed by path
+                        content_str = re.sub(
+                            r'wss?://[^/\s"]+',
+                            f'ws://localhost:{self.local_port}',
+                            content_str
                         )
+                        logger.debug("CDP /json rewritten: %s", content_str[:200])
+                        content = content_str.encode("utf-8")
+
+                    return web.Response(
+                        body=content,
+                        status=response.status,
+                        content_type=response.content_type
+                    )
         except Exception as e:
             logger.error("CDP HTTP proxy error: %s", e, exc_info=True)
             return web.Response(text=str(e), status=502)
@@ -678,57 +557,45 @@ class CDPProxyServer:
         await ws_client.prepare(request)
 
         remote_url = f"wss://{self.target_host}{path}"
+        # Note: Host header is handled by the internal proxy in the sandbox
+        headers = {"X-Access-Token": self.access_token}
 
         logger.debug("CDP WebSocket: %s -> %s", path, remote_url)
 
         try:
             async with aiohttp.ClientSession() as session:
-                for include_traffic in (False, True):
-                    # Note: Host header is handled by the internal proxy in the sandbox.
-                    headers = _build_auth_headers(
-                        self.envd_access_token,
-                        self.traffic_access_token,
-                        include_traffic=include_traffic,
+                async with session.ws_connect(remote_url, headers=headers) as ws_remote:
+                    # Create tasks for bidirectional forwarding
+                    async def forward_client_to_remote():
+                        try:
+                            async for msg in ws_client:
+                                if msg.type == aiohttp.WSMsgType.TEXT:
+                                    await ws_remote.send_str(msg.data)
+                                elif msg.type == aiohttp.WSMsgType.BINARY:
+                                    await ws_remote.send_bytes(msg.data)
+                                elif msg.type == aiohttp.WSMsgType.CLOSE:
+                                    break
+                        except Exception as e:
+                            logger.debug("Client->Remote forward ended: %s", e)
+
+                    async def forward_remote_to_client():
+                        try:
+                            async for msg in ws_remote:
+                                if msg.type == aiohttp.WSMsgType.TEXT:
+                                    await ws_client.send_str(msg.data)
+                                elif msg.type == aiohttp.WSMsgType.BINARY:
+                                    await ws_client.send_bytes(msg.data)
+                                elif msg.type == aiohttp.WSMsgType.CLOSE:
+                                    break
+                        except Exception as e:
+                            logger.debug("Remote->Client forward ended: %s", e)
+
+                    # Run both forwarding tasks
+                    await asyncio.gather(
+                        forward_client_to_remote(),
+                        forward_remote_to_client(),
+                        return_exceptions=True
                     )
-                    try:
-                        async with session.ws_connect(remote_url, headers=headers, ssl=_PERMISSIVE_SSL) as ws_remote:
-                            # Create tasks for bidirectional forwarding
-                            async def forward_client_to_remote():
-                                try:
-                                    async for msg in ws_client:
-                                        if msg.type == aiohttp.WSMsgType.TEXT:
-                                            await ws_remote.send_str(msg.data)
-                                        elif msg.type == aiohttp.WSMsgType.BINARY:
-                                            await ws_remote.send_bytes(msg.data)
-                                        elif msg.type == aiohttp.WSMsgType.CLOSE:
-                                            break
-                                except Exception as e:
-                                    logger.debug("Client->Remote forward ended: %s", e)
-
-                            async def forward_remote_to_client():
-                                try:
-                                    async for msg in ws_remote:
-                                        if msg.type == aiohttp.WSMsgType.TEXT:
-                                            await ws_client.send_str(msg.data)
-                                        elif msg.type == aiohttp.WSMsgType.BINARY:
-                                            await ws_client.send_bytes(msg.data)
-                                        elif msg.type == aiohttp.WSMsgType.CLOSE:
-                                            break
-                                except Exception as e:
-                                    logger.debug("Remote->Client forward ended: %s", e)
-
-                            # Run both forwarding tasks
-                            await asyncio.gather(
-                                forward_client_to_remote(),
-                                forward_remote_to_client(),
-                                return_exceptions=True
-                            )
-                        break
-                    except aiohttp.WSServerHandshakeError as e:
-                        if _should_retry_with_traffic(e.status, self.traffic_access_token, include_traffic):
-                            logger.debug("Retrying CDP WebSocket %s with traffic token after %d", path, e.status)
-                            continue
-                        raise
 
         except Exception as e:
             logger.error("CDP WebSocket proxy error: %s", e)
@@ -805,7 +672,6 @@ class AGSProvider(Provider):
         self.sandbox = None
         self.sandbox_id = None
         self.envd_access_token = None
-        self.traffic_access_token = None
 
         # Local proxy servers
         self.proxy_servers = {}
@@ -833,12 +699,7 @@ class AGSProvider(Provider):
         for name, remote_port, local_start in http_port_mapping:
             remote_host = self._get_sandbox_host(remote_port)
 
-            proxy = LocalProxyServer(
-                local_start,
-                remote_host,
-                self.envd_access_token,
-                self.traffic_access_token,
-            )
+            proxy = LocalProxyServer(local_start, remote_host, self.envd_access_token)
             proxy.start()  # This will retry and update local_port if needed
             self.proxy_servers[name] = proxy
 
@@ -852,12 +713,7 @@ class AGSProvider(Provider):
 
         # CDP proxy for Chromium (supports WebSocket)
         chromium_remote_host = self._get_sandbox_host(CHROMIUM_PORT)
-        cdp_proxy = CDPProxyServer(
-            19222,
-            chromium_remote_host,
-            self.envd_access_token,
-            self.traffic_access_token,
-        )
+        cdp_proxy = CDPProxyServer(19222, chromium_remote_host, self.envd_access_token)
         cdp_proxy.start()  # This will retry and update local_port if needed
         self.proxy_servers["chromium"] = cdp_proxy
         self.local_chromium_port = cdp_proxy.local_port
@@ -918,63 +774,62 @@ class AGSProvider(Provider):
 
         This method:
         1. Deploys /tmp/cdp_proxy.py script (standard library only)
-        2. Deploys /tmp/socat_wrapper
-        3. Uses sudo to replace /usr/bin/socat with a wrapper that intercepts
+        2. Uses sudo to replace /usr/bin/socat with a wrapper that intercepts
            "socat tcp-listen:9222,fork tcp:localhost:1337" calls from task setup,
            starts cdp_proxy.py instead, and passes other socat calls through.
         """
+        import json as json_module
         exec_url = f"http://localhost:{self.local_server_port}/setup/execute"
+        headers = {"Content-Type": "application/json"}
 
-        def exec_shell(cmd: str, critical: bool = False, max_retries: int = 1) -> dict:
+        def exec_shell(cmd: str) -> dict:
             """Execute a shell command in the sandbox."""
-            last_error = None
-            for attempt in range(max_retries):
-                try:
-                    resp = requests.post(
-                        exec_url,
-                        json={"command": cmd, "shell": True},
-                        timeout=180,
-                    )
-                    if resp.status_code == 200:
-                        result = resp.json()
-                        logger.debug("exec '%s': %s", cmd[:80], result.get("output", "")[:200])
-                        return result
-                    last_error = f"HTTP {resp.status_code}: {resp.text[:300]}"
-                except Exception as e:
-                    last_error = str(e)
+            try:
+                payload = json_module.dumps({"command": cmd, "shell": True})
+                resp = requests.post(exec_url, headers=headers, data=payload, timeout=120)
+                if resp.status_code == 200:
+                    result = resp.json()
+                    logger.debug("exec '%s': %s", cmd[:50], result.get("output", "")[:200])
+                    return result
+                else:
+                    logger.warning("exec '%s' failed: %s", cmd[:50], resp.text[:200])
+                    return {"status": "error", "output": resp.text}
+            except Exception as e:
+                logger.warning("exec '%s' error: %s", cmd[:50], e)
+                return {"status": "error", "output": str(e)}
 
-                if attempt < max_retries - 1:
-                    logger.warning(
-                        "CDP deploy attempt %d/%d failed: %s",
-                        attempt + 1,
-                        max_retries,
-                        last_error,
-                    )
-                    time.sleep(2)
+        proxy_script = _read_cdp_proxy_script()
+        write_cmd = f"cat > /tmp/cdp_proxy.py << 'CDPPROXYSCRIPT'\n{proxy_script}\nCDPPROXYSCRIPT"
+        exec_shell(write_cmd)
 
-            if critical:
-                raise RuntimeError(f"Critical CDP bridge deploy command failed: {last_error}; cmd={cmd[:120]}")
-            logger.warning("CDP bridge deploy command failed: %s; cmd=%s", last_error, cmd[:120])
-            return {"status": "error", "output": str(last_error)}
-
-        logger.info("Deploying standard-library CDP bridge scripts to sandbox...")
-
-        exec_shell(
-            f"cat > /tmp/cdp_proxy.py << 'AGS_CDP_EOF'\n{_read_cdp_proxy_script()}\nAGS_CDP_EOF",
-            critical=True,
-            max_retries=3,
+        # Install socat wrapper using sudo (password: password).
+        # 1. Backup real socat binary
+        # 2. Replace /usr/bin/socat with a bash wrapper that:
+        #    - Intercepts "socat tcp-listen:9222,..." and starts cdp_proxy.py instead
+        #    - Passes all other socat calls through to the real binary
+        socat_wrapper = (
+            '#!/bin/bash\n'
+            'REAL=/usr/bin/socat.real\n'
+            'for arg in "$@"; do\n'
+            '  case "$arg" in\n'
+            '    tcp-listen:9222*)\n'
+            '      nohup python3 /tmp/cdp_proxy.py >/tmp/cdp_proxy.log 2>&1 &\n'
+            '      for i in $(seq 1 50); do\n'
+            '        ss -tlnp 2>/dev/null | grep -q ":9222 " && exit 0\n'
+            '        sleep 0.2\n'
+            '      done\n'
+            '      exit 0\n'
+            '      ;;\n'
+            '  esac\n'
+            'done\n'
+            'exec "$REAL" "$@"\n'
         )
-        exec_shell(
-            f"cat > /tmp/socat_wrapper << 'AGS_CDP_EOF'\n{SOCAT_WRAPPER_SCRIPT}\nAGS_CDP_EOF",
-            critical=True,
-            max_retries=3,
-        )
-        exec_shell("chmod +x /tmp/socat_wrapper", critical=True, max_retries=2)
-
-        password = shlex.quote(os.environ.get("AGS_CLIENT_PASSWORD", "password"))
-        exec_shell(f"echo {password} | sudo -S cp /usr/bin/socat /usr/bin/socat.real || true")
-        exec_shell(f"echo {password} | sudo -S cp /tmp/socat_wrapper /usr/bin/socat", critical=True, max_retries=2)
-        exec_shell(f"echo {password} | sudo -S chmod +x /usr/bin/socat", critical=True, max_retries=2)
+        # Write wrapper to /tmp first, then use sudo to install
+        exec_shell(f"cat > /tmp/socat_wrapper << 'SOCATWRAPPER'\n{socat_wrapper}SOCATWRAPPER")
+        exec_shell("chmod +x /tmp/socat_wrapper")
+        exec_shell("echo password | sudo -S cp /usr/bin/socat /usr/bin/socat.real")
+        exec_shell("echo password | sudo -S cp /tmp/socat_wrapper /usr/bin/socat")
+        exec_shell("echo password | sudo -S chmod +x /usr/bin/socat")
 
         # Verify wrapper is installed
         result = exec_shell("file /usr/bin/socat && file /usr/bin/socat.real")
@@ -1011,9 +866,6 @@ class AGSProvider(Provider):
             self.envd_access_token = getattr(
                 self.sandbox, "_SandboxBase__envd_access_token", None
             )
-        self.traffic_access_token = getattr(self.sandbox, "traffic_access_token", None)
-        if not self.traffic_access_token:
-            self.traffic_access_token = getattr(self.sandbox, "trafficAccessToken", None)
 
         logger.info("AGS sandbox created with ID: %s", self.sandbox_id)
 
@@ -1046,8 +898,8 @@ class AGSProvider(Provider):
         raise NotImplementedError("Snapshots not available for AGS provider")
 
     def revert_to_snapshot(self, path_to_vm: str, snapshot_name: str):
-        """Revert by stopping and restarting the sandbox."""
-        logger.info("AGS snapshot revert requested; replacing sandbox with a fresh instance.")
+        """Replace the sandbox because AGS does not expose OSWorld VM snapshots."""
+        logger.warning("AGS snapshot revert not supported; replacing sandbox.")
         self.stop_emulator(path_to_vm)
 
     def stop_emulator(self, path_to_vm: str, region=None, *args, **kwargs):
@@ -1068,6 +920,5 @@ class AGSProvider(Provider):
                 self.sandbox = None
                 self.sandbox_id = None
                 self.envd_access_token = None
-                self.traffic_access_token = None
         else:
             logger.warning("stop_emulator called but sandbox is None")

--- a/examples/osworld-ags/overlay/OSWorld/desktop_env/providers/ags/provider.py
+++ b/examples/osworld-ags/overlay/OSWorld/desktop_env/providers/ags/provider.py
@@ -214,13 +214,11 @@ def _build_auth_headers(
     headers = {}
     if envd_access_token:
         headers["X-Access-Token"] = envd_access_token
-    if include_traffic and traffic_access_token:
-        headers["e2b-traffic-access-token"] = traffic_access_token
     return headers
 
 
 def _should_retry_with_traffic(status: int | None, traffic_access_token: str | None, include_traffic: bool) -> bool:
-    return bool(traffic_access_token) and not include_traffic and status in (401, 403)
+    return False
 
 
 class LocalProxyServer:

--- a/examples/osworld-ags/overlay/OSWorld/desktop_env/providers/ags/provider.py
+++ b/examples/osworld-ags/overlay/OSWorld/desktop_env/providers/ags/provider.py
@@ -4,14 +4,20 @@ Modified and redistributed by Agent Sandbox Cookbook as part of the OSWorld AGS 
 """
 
 import atexit
+import json
 import logging
+import os
 import signal
+import shlex
+import ssl
 import time
 import threading
 import socket
 import re
 import requests
 import weakref
+from pathlib import Path
+from urllib.parse import urlparse, urlunparse
 
 from desktop_env.providers.base import Provider
 from desktop_env.providers.ags.config import (
@@ -88,6 +94,74 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
     logger.warning("aiohttp package not available, CDP proxy will have limited functionality")
 
+if AIOHTTP_AVAILABLE:
+    _PERMISSIVE_SSL = ssl.create_default_context()
+    _PERMISSIVE_SSL.check_hostname = False
+    _PERMISSIVE_SSL.verify_mode = ssl.CERT_NONE
+
+
+def _rewrite_cdp_url(raw: str, local_port: int) -> str:
+    """Rewrite CDP URLs to the local proxy port used by Playwright."""
+    if not isinstance(raw, str):
+        return raw
+    parsed = urlparse(raw)
+    if parsed.scheme in ("ws", "wss"):
+        return urlunparse(("ws", f"127.0.0.1:{local_port}", parsed.path, "", parsed.query, parsed.fragment))
+    if parsed.scheme in ("http", "https"):
+        return urlunparse(("http", f"127.0.0.1:{local_port}", parsed.path, "", parsed.query, parsed.fragment))
+    return raw
+
+
+def _rewrite_cdp_payload(content: bytes, local_port: int) -> bytes:
+    """Rewrite CDP /json responses so WS connections go through the local proxy."""
+    try:
+        payload = json.loads(content.decode("utf-8"))
+    except Exception:
+        content_str = content.decode("utf-8", errors="replace")
+        content_str = re.sub(r"wss?://[^/\s\"]+:\d+", f"ws://127.0.0.1:{local_port}", content_str)
+        return content_str.encode("utf-8")
+
+    def rewrite_item(item):
+        if isinstance(item, dict):
+            rewritten = dict(item)
+            for key in ("webSocketDebuggerUrl", "devtoolsFrontendUrl"):
+                if key in rewritten:
+                    rewritten[key] = _rewrite_cdp_url(rewritten[key], local_port)
+            return rewritten
+        return item
+
+    if isinstance(payload, list):
+        payload = [rewrite_item(item) for item in payload]
+    elif isinstance(payload, dict):
+        payload = rewrite_item(payload)
+
+    return json.dumps(payload).encode("utf-8")
+
+
+CDP_PROXY_SOURCE = Path(__file__).with_name("cdp_proxy.py")
+
+
+def _read_cdp_proxy_script() -> str:
+    return CDP_PROXY_SOURCE.read_text(encoding="utf-8")
+
+SOCAT_WRAPPER_SCRIPT = (
+    '#!/bin/bash\n'
+    'REAL=/usr/bin/socat.real\n'
+    'for arg in "$@"; do\n'
+    '  case "$arg" in\n'
+    '    tcp-listen:9222*)\n'
+    '      nohup python3 /tmp/cdp_proxy.py >/tmp/cdp_proxy.log 2>&1 &\n'
+    '      for i in $(seq 1 50); do\n'
+    "        ss -tlnp 2>/dev/null | grep -q ':9222 ' && exit 0\n"
+    '        sleep 0.2\n'
+    '      done\n'
+    '      exit 0\n'
+    '      ;;\n'
+    '  esac\n'
+    'done\n'
+    'exec "$REAL" "$@"\n'
+)
+
 
 def find_available_port(start_port: int) -> int:
     """Find an available port starting from start_port."""
@@ -132,6 +206,23 @@ def find_and_bind_port(start_port: int, max_retries: int = 100) -> socket.socket
     raise RuntimeError(f"No available port found starting from {start_port}")
 
 
+def _build_auth_headers(
+    envd_access_token: str | None,
+    traffic_access_token: str | None,
+    include_traffic: bool = False,
+) -> dict:
+    headers = {}
+    if envd_access_token:
+        headers["X-Access-Token"] = envd_access_token
+    if include_traffic and traffic_access_token:
+        headers["e2b-traffic-access-token"] = traffic_access_token
+    return headers
+
+
+def _should_retry_with_traffic(status: int | None, traffic_access_token: str | None, include_traffic: bool) -> bool:
+    return bool(traffic_access_token) and not include_traffic and status in (401, 403)
+
+
 class LocalProxyServer:
     """
     Local proxy server for AGS sandbox, supporting both HTTP and WebSocket.
@@ -140,10 +231,17 @@ class LocalProxyServer:
     This is essential for services like noVNC that use WebSocket (websockify).
     """
 
-    def __init__(self, local_port: int, target_host: str, access_token: str):
+    def __init__(
+        self,
+        local_port: int,
+        target_host: str,
+        envd_access_token: str | None,
+        traffic_access_token: str | None,
+    ):
         self.local_port = local_port
         self.target_host = target_host
-        self.access_token = access_token
+        self.envd_access_token = envd_access_token
+        self.traffic_access_token = traffic_access_token
         self.thread = None
         self.loop = None
         self.runner = None
@@ -200,7 +298,7 @@ class LocalProxyServer:
     async def _start_server(self):
         """Start the aiohttp web server with retry on port conflict."""
         import random
-        app = web.Application()
+        app = web.Application(client_max_size=0)
 
         # Route all requests through our handler
         app.router.add_route('*', '/{path:.*}', self._handle_request)
@@ -246,51 +344,65 @@ class LocalProxyServer:
     async def _handle_http(self, request: web.Request, path: str):
         """Handle HTTP request by proxying to the remote sandbox."""
         target_url = f"https://{self.target_host}{path}"
-        headers = {"X-Access-Token": self.access_token}
-
-        # Forward original headers (except host)
-        for key, value in request.headers.items():
-            if key.lower() not in ("host", "transfer-encoding"):
-                headers[key] = value
-        headers["X-Access-Token"] = self.access_token
-
         body = await request.read()
 
         logger.debug("Proxy HTTP %s: %s -> %s", request.method, path, target_url)
 
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.request(
-                    request.method,
-                    target_url,
-                    headers=headers,
-                    data=body if body else None,
-                    timeout=aiohttp.ClientTimeout(total=300, connect=30),
-                ) as response:
-                    content = await response.read()
-
-                    if response.status >= 500:
-                        logger.warning(
-                            "Remote returned error %d for %s: %s",
-                            response.status, path,
-                            content.decode('utf-8', errors='replace')[:500]
-                        )
-                    elif response.status >= 400:
-                        logger.debug(
-                            "Remote returned %d for %s",
-                            response.status, path,
-                        )
-
-                    resp_headers = {}
-                    for key, value in response.headers.items():
-                        if key.lower() not in ("transfer-encoding", "content-encoding", "content-length"):
-                            resp_headers[key] = value
-
-                    return web.Response(
-                        body=content,
-                        status=response.status,
-                        headers=resp_headers,
+                for include_traffic in (False, True):
+                    headers = _build_auth_headers(
+                        self.envd_access_token,
+                        self.traffic_access_token,
+                        include_traffic=include_traffic,
                     )
+
+                    # Forward original headers (except hop-by-hop and auth headers).
+                    for key, value in request.headers.items():
+                        if key.lower() not in (
+                            "host",
+                            "transfer-encoding",
+                            "x-access-token",
+                            "e2b-traffic-access-token",
+                        ):
+                            headers[key] = value
+
+                    async with session.request(
+                        request.method,
+                        target_url,
+                        headers=headers,
+                        data=body if body else None,
+                        timeout=aiohttp.ClientTimeout(total=300, connect=30),
+                        ssl=_PERMISSIVE_SSL,
+                    ) as response:
+                        content = await response.read()
+
+                        if _should_retry_with_traffic(response.status, self.traffic_access_token, include_traffic):
+                            logger.debug("Retrying %s with traffic token after %d", path, response.status)
+                            continue
+
+                        if response.status >= 500:
+                            logger.warning(
+                                "Remote returned error %d for %s: %s",
+                                response.status, path,
+                                content.decode('utf-8', errors='replace')[:500]
+                            )
+                        elif response.status >= 400:
+                            logger.debug(
+                                "Remote returned %d for %s",
+                                response.status, path,
+                            )
+
+                        resp_headers = {}
+                        for key, value in response.headers.items():
+                            if key.lower() not in ("transfer-encoding", "content-encoding", "content-length"):
+                                resp_headers[key] = value
+
+                        return web.Response(
+                            body=content,
+                            status=response.status,
+                            headers=resp_headers,
+                        )
         except Exception as e:
             logger.error("Proxy HTTP error for %s: %s", path, e)
             return web.Response(text=str(e), status=502)
@@ -301,42 +413,54 @@ class LocalProxyServer:
         await ws_client.prepare(request)
 
         remote_url = f"wss://{self.target_host}{path}"
-        headers = {"X-Access-Token": self.access_token}
 
         logger.debug("Proxy WebSocket: %s -> %s", path, remote_url)
 
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.ws_connect(remote_url, headers=headers) as ws_remote:
-                    async def forward_client_to_remote():
-                        try:
-                            async for msg in ws_client:
-                                if msg.type == aiohttp.WSMsgType.TEXT:
-                                    await ws_remote.send_str(msg.data)
-                                elif msg.type == aiohttp.WSMsgType.BINARY:
-                                    await ws_remote.send_bytes(msg.data)
-                                elif msg.type == aiohttp.WSMsgType.CLOSE:
-                                    break
-                        except Exception as e:
-                            logger.debug("Client->Remote forward ended: %s", e)
-
-                    async def forward_remote_to_client():
-                        try:
-                            async for msg in ws_remote:
-                                if msg.type == aiohttp.WSMsgType.TEXT:
-                                    await ws_client.send_str(msg.data)
-                                elif msg.type == aiohttp.WSMsgType.BINARY:
-                                    await ws_client.send_bytes(msg.data)
-                                elif msg.type == aiohttp.WSMsgType.CLOSE:
-                                    break
-                        except Exception as e:
-                            logger.debug("Remote->Client forward ended: %s", e)
-
-                    await asyncio.gather(
-                        forward_client_to_remote(),
-                        forward_remote_to_client(),
-                        return_exceptions=True,
+                for include_traffic in (False, True):
+                    headers = _build_auth_headers(
+                        self.envd_access_token,
+                        self.traffic_access_token,
+                        include_traffic=include_traffic,
                     )
+                    try:
+                        async with session.ws_connect(remote_url, headers=headers, ssl=_PERMISSIVE_SSL) as ws_remote:
+                            async def forward_client_to_remote():
+                                try:
+                                    async for msg in ws_client:
+                                        if msg.type == aiohttp.WSMsgType.TEXT:
+                                            await ws_remote.send_str(msg.data)
+                                        elif msg.type == aiohttp.WSMsgType.BINARY:
+                                            await ws_remote.send_bytes(msg.data)
+                                        elif msg.type == aiohttp.WSMsgType.CLOSE:
+                                            break
+                                except Exception as e:
+                                    logger.debug("Client->Remote forward ended: %s", e)
+
+                            async def forward_remote_to_client():
+                                try:
+                                    async for msg in ws_remote:
+                                        if msg.type == aiohttp.WSMsgType.TEXT:
+                                            await ws_client.send_str(msg.data)
+                                        elif msg.type == aiohttp.WSMsgType.BINARY:
+                                            await ws_client.send_bytes(msg.data)
+                                        elif msg.type == aiohttp.WSMsgType.CLOSE:
+                                            break
+                                except Exception as e:
+                                    logger.debug("Remote->Client forward ended: %s", e)
+
+                            await asyncio.gather(
+                                forward_client_to_remote(),
+                                forward_remote_to_client(),
+                                return_exceptions=True,
+                            )
+                        break
+                    except aiohttp.WSServerHandshakeError as e:
+                        if _should_retry_with_traffic(e.status, self.traffic_access_token, include_traffic):
+                            logger.debug("Retrying WebSocket %s with traffic token after %d", path, e.status)
+                            continue
+                        raise
 
         except Exception as e:
             logger.error("Proxy WebSocket error: %s", e)
@@ -397,10 +521,17 @@ class CDPProxyServer:
     Uses aiohttp to handle both HTTP requests and WebSocket connections on the same port.
     """
 
-    def __init__(self, local_port: int, target_host: str, access_token: str):
+    def __init__(
+        self,
+        local_port: int,
+        target_host: str,
+        envd_access_token: str | None,
+        traffic_access_token: str | None,
+    ):
         self.local_port = local_port
         self.target_host = target_host
-        self.access_token = access_token
+        self.envd_access_token = envd_access_token
+        self.traffic_access_token = traffic_access_token
         self.thread = None
         self.loop = None
         self.runner = None
@@ -457,7 +588,7 @@ class CDPProxyServer:
     async def _start_server(self):
         """Start the aiohttp web server with retry on port conflict."""
         import random
-        app = web.Application()
+        app = web.Application(client_max_size=0)
 
         # Route all requests through our handler
         app.router.add_route('*', '/{path:.*}', self._handle_request)
@@ -506,41 +637,39 @@ class CDPProxyServer:
     async def _handle_http(self, request: web.Request, path: str):
         """Handle HTTP request."""
         target_url = f"https://{self.target_host}{path}"
-        # Note: Host header is handled by the internal proxy in the sandbox
-        headers = {"X-Access-Token": self.access_token}
 
         logger.debug("CDP HTTP: %s -> %s", path, target_url)
 
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.get(target_url, headers=headers) as response:
-                    content = await response.read()
-
-                    # If remote returns error, log it clearly
-                    if response.status >= 400:
-                        logger.error("Remote CDP returned error %d: %s",
-                                   response.status, content.decode('utf-8', errors='replace')[:500])
-
-                    # Rewrite WebSocket URLs in /json/* responses
-                    if path.startswith("/json") and response.status == 200:
-                        content_str = content.decode("utf-8")
-                        logger.debug("CDP /json response: %s", content_str[:200])
-
-                        # Replace remote WebSocket URLs with local
-                        # Pattern matches wss://host or ws://host followed by path
-                        content_str = re.sub(
-                            r'wss?://[^/\s"]+',
-                            f'ws://localhost:{self.local_port}',
-                            content_str
-                        )
-                        logger.debug("CDP /json rewritten: %s", content_str[:200])
-                        content = content_str.encode("utf-8")
-
-                    return web.Response(
-                        body=content,
-                        status=response.status,
-                        content_type=response.content_type
+                for include_traffic in (False, True):
+                    # Note: Host header is handled by the internal proxy in the sandbox.
+                    headers = _build_auth_headers(
+                        self.envd_access_token,
+                        self.traffic_access_token,
+                        include_traffic=include_traffic,
                     )
+                    async with session.get(target_url, headers=headers, ssl=_PERMISSIVE_SSL) as response:
+                        content = await response.read()
+
+                        if _should_retry_with_traffic(response.status, self.traffic_access_token, include_traffic):
+                            logger.debug("Retrying CDP HTTP %s with traffic token after %d", path, response.status)
+                            continue
+
+                        # If remote returns error, log it clearly
+                        if response.status >= 400:
+                            logger.error("Remote CDP returned error %d: %s",
+                                       response.status, content.decode('utf-8', errors='replace')[:500])
+
+                        # Rewrite WebSocket URLs in /json/* responses
+                        if path.startswith("/json") and response.status == 200:
+                            content = _rewrite_cdp_payload(content, self.local_port)
+
+                        return web.Response(
+                            body=content,
+                            status=response.status,
+                            content_type=response.content_type
+                        )
         except Exception as e:
             logger.error("CDP HTTP proxy error: %s", e, exc_info=True)
             return web.Response(text=str(e), status=502)
@@ -551,45 +680,57 @@ class CDPProxyServer:
         await ws_client.prepare(request)
 
         remote_url = f"wss://{self.target_host}{path}"
-        # Note: Host header is handled by the internal proxy in the sandbox
-        headers = {"X-Access-Token": self.access_token}
 
         logger.debug("CDP WebSocket: %s -> %s", path, remote_url)
 
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.ws_connect(remote_url, headers=headers) as ws_remote:
-                    # Create tasks for bidirectional forwarding
-                    async def forward_client_to_remote():
-                        try:
-                            async for msg in ws_client:
-                                if msg.type == aiohttp.WSMsgType.TEXT:
-                                    await ws_remote.send_str(msg.data)
-                                elif msg.type == aiohttp.WSMsgType.BINARY:
-                                    await ws_remote.send_bytes(msg.data)
-                                elif msg.type == aiohttp.WSMsgType.CLOSE:
-                                    break
-                        except Exception as e:
-                            logger.debug("Client->Remote forward ended: %s", e)
-
-                    async def forward_remote_to_client():
-                        try:
-                            async for msg in ws_remote:
-                                if msg.type == aiohttp.WSMsgType.TEXT:
-                                    await ws_client.send_str(msg.data)
-                                elif msg.type == aiohttp.WSMsgType.BINARY:
-                                    await ws_client.send_bytes(msg.data)
-                                elif msg.type == aiohttp.WSMsgType.CLOSE:
-                                    break
-                        except Exception as e:
-                            logger.debug("Remote->Client forward ended: %s", e)
-
-                    # Run both forwarding tasks
-                    await asyncio.gather(
-                        forward_client_to_remote(),
-                        forward_remote_to_client(),
-                        return_exceptions=True
+                for include_traffic in (False, True):
+                    # Note: Host header is handled by the internal proxy in the sandbox.
+                    headers = _build_auth_headers(
+                        self.envd_access_token,
+                        self.traffic_access_token,
+                        include_traffic=include_traffic,
                     )
+                    try:
+                        async with session.ws_connect(remote_url, headers=headers, ssl=_PERMISSIVE_SSL) as ws_remote:
+                            # Create tasks for bidirectional forwarding
+                            async def forward_client_to_remote():
+                                try:
+                                    async for msg in ws_client:
+                                        if msg.type == aiohttp.WSMsgType.TEXT:
+                                            await ws_remote.send_str(msg.data)
+                                        elif msg.type == aiohttp.WSMsgType.BINARY:
+                                            await ws_remote.send_bytes(msg.data)
+                                        elif msg.type == aiohttp.WSMsgType.CLOSE:
+                                            break
+                                except Exception as e:
+                                    logger.debug("Client->Remote forward ended: %s", e)
+
+                            async def forward_remote_to_client():
+                                try:
+                                    async for msg in ws_remote:
+                                        if msg.type == aiohttp.WSMsgType.TEXT:
+                                            await ws_client.send_str(msg.data)
+                                        elif msg.type == aiohttp.WSMsgType.BINARY:
+                                            await ws_client.send_bytes(msg.data)
+                                        elif msg.type == aiohttp.WSMsgType.CLOSE:
+                                            break
+                                except Exception as e:
+                                    logger.debug("Remote->Client forward ended: %s", e)
+
+                            # Run both forwarding tasks
+                            await asyncio.gather(
+                                forward_client_to_remote(),
+                                forward_remote_to_client(),
+                                return_exceptions=True
+                            )
+                        break
+                    except aiohttp.WSServerHandshakeError as e:
+                        if _should_retry_with_traffic(e.status, self.traffic_access_token, include_traffic):
+                            logger.debug("Retrying CDP WebSocket %s with traffic token after %d", path, e.status)
+                            continue
+                        raise
 
         except Exception as e:
             logger.error("CDP WebSocket proxy error: %s", e)
@@ -666,6 +807,7 @@ class AGSProvider(Provider):
         self.sandbox = None
         self.sandbox_id = None
         self.envd_access_token = None
+        self.traffic_access_token = None
 
         # Local proxy servers
         self.proxy_servers = {}
@@ -693,7 +835,12 @@ class AGSProvider(Provider):
         for name, remote_port, local_start in http_port_mapping:
             remote_host = self._get_sandbox_host(remote_port)
 
-            proxy = LocalProxyServer(local_start, remote_host, self.envd_access_token)
+            proxy = LocalProxyServer(
+                local_start,
+                remote_host,
+                self.envd_access_token,
+                self.traffic_access_token,
+            )
             proxy.start()  # This will retry and update local_port if needed
             self.proxy_servers[name] = proxy
 
@@ -707,7 +854,12 @@ class AGSProvider(Provider):
 
         # CDP proxy for Chromium (supports WebSocket)
         chromium_remote_host = self._get_sandbox_host(CHROMIUM_PORT)
-        cdp_proxy = CDPProxyServer(19222, chromium_remote_host, self.envd_access_token)
+        cdp_proxy = CDPProxyServer(
+            19222,
+            chromium_remote_host,
+            self.envd_access_token,
+            self.traffic_access_token,
+        )
         cdp_proxy.start()  # This will retry and update local_port if needed
         self.proxy_servers["chromium"] = cdp_proxy
         self.local_chromium_port = cdp_proxy.local_port
@@ -767,136 +919,64 @@ class AGSProvider(Provider):
         (e.g., "launch google-chrome --remote-debugging-port=1337").
 
         This method:
-        1. Installs aiohttp dependency
-        2. Deploys /tmp/cdp_proxy.py script (rewrites Host header for Chrome CDP)
+        1. Deploys /tmp/cdp_proxy.py script (standard library only)
+        2. Deploys /tmp/socat_wrapper
         3. Uses sudo to replace /usr/bin/socat with a wrapper that intercepts
            "socat tcp-listen:9222,fork tcp:localhost:1337" calls from task setup,
            starts cdp_proxy.py instead, and passes other socat calls through.
         """
-        import json as json_module
         exec_url = f"http://localhost:{self.local_server_port}/setup/execute"
-        headers = {"Content-Type": "application/json"}
 
-        def exec_shell(cmd: str) -> dict:
+        def exec_shell(cmd: str, critical: bool = False, max_retries: int = 1) -> dict:
             """Execute a shell command in the sandbox."""
-            try:
-                payload = json_module.dumps({"command": cmd, "shell": True})
-                resp = requests.post(exec_url, headers=headers, data=payload, timeout=120)
-                if resp.status_code == 200:
-                    result = resp.json()
-                    logger.debug("exec '%s': %s", cmd[:50], result.get("output", "")[:200])
-                    return result
-                else:
-                    logger.warning("exec '%s' failed: %s", cmd[:50], resp.text[:200])
-                    return {"status": "error", "output": resp.text}
-            except Exception as e:
-                logger.warning("exec '%s' error: %s", cmd[:50], e)
-                return {"status": "error", "output": str(e)}
+            last_error = None
+            for attempt in range(max_retries):
+                try:
+                    resp = requests.post(
+                        exec_url,
+                        json={"command": cmd, "shell": True},
+                        timeout=180,
+                    )
+                    if resp.status_code == 200:
+                        result = resp.json()
+                        logger.debug("exec '%s': %s", cmd[:80], result.get("output", "")[:200])
+                        return result
+                    last_error = f"HTTP {resp.status_code}: {resp.text[:300]}"
+                except Exception as e:
+                    last_error = str(e)
 
-        # Ensure aiohttp is installed
-        exec_shell("python3 -c 'import aiohttp' 2>/dev/null || pip3 install --quiet aiohttp")
+                if attempt < max_retries - 1:
+                    logger.warning(
+                        "CDP deploy attempt %d/%d failed: %s",
+                        attempt + 1,
+                        max_retries,
+                        last_error,
+                    )
+                    time.sleep(2)
 
-        # Create CDP proxy script that rewrites Host header
-        proxy_script = r'''
-import asyncio
-import aiohttp
-from aiohttp import web
-import re
+            if critical:
+                raise RuntimeError(f"Critical CDP bridge deploy command failed: {last_error}; cmd={cmd[:120]}")
+            logger.warning("CDP bridge deploy command failed: %s; cmd=%s", last_error, cmd[:120])
+            return {"status": "error", "output": str(last_error)}
 
-CHROME_HOST = "127.0.0.1"
-CHROME_PORT = 1337
+        logger.info("Deploying standard-library CDP bridge scripts to sandbox...")
 
-async def handle_http(request):
-    path = request.path
-    if request.query_string:
-        path += "?" + request.query_string
-    url = f"http://{CHROME_HOST}:{CHROME_PORT}{path}"
-    headers = {"Host": f"localhost:{CHROME_PORT}"}
-    try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(url, headers=headers) as resp:
-                content = await resp.read()
-                if path.startswith("/json"):
-                    content_str = content.decode("utf-8")
-                    content_str = re.sub(r"ws://[^/\s\"]+:1337", "ws://localhost:9222", content_str)
-                    content_str = content_str.replace(f"localhost:{CHROME_PORT}", "localhost:9222")
-                    content = content_str.encode("utf-8")
-                return web.Response(body=content, status=resp.status, content_type=resp.content_type)
-    except Exception as e:
-        return web.Response(text=str(e), status=502)
-
-async def handle_websocket(request):
-    ws_client = web.WebSocketResponse()
-    await ws_client.prepare(request)
-    path = request.path
-    url = f"ws://{CHROME_HOST}:{CHROME_PORT}{path}"
-    headers = {"Host": f"localhost:{CHROME_PORT}"}
-    try:
-        async with aiohttp.ClientSession() as session:
-            async with session.ws_connect(url, headers=headers) as ws_remote:
-                async def forward_to_remote():
-                    async for msg in ws_client:
-                        if msg.type == aiohttp.WSMsgType.TEXT:
-                            await ws_remote.send_str(msg.data)
-                        elif msg.type == aiohttp.WSMsgType.BINARY:
-                            await ws_remote.send_bytes(msg.data)
-                        elif msg.type == aiohttp.WSMsgType.CLOSE:
-                            break
-                async def forward_to_client():
-                    async for msg in ws_remote:
-                        if msg.type == aiohttp.WSMsgType.TEXT:
-                            await ws_client.send_str(msg.data)
-                        elif msg.type == aiohttp.WSMsgType.BINARY:
-                            await ws_client.send_bytes(msg.data)
-                        elif msg.type == aiohttp.WSMsgType.CLOSE:
-                            break
-                await asyncio.gather(forward_to_remote(), forward_to_client(), return_exceptions=True)
-    except Exception as e:
-        print(f"WebSocket error: {e}")
-    return ws_client
-
-async def handle_request(request):
-    if request.headers.get("Upgrade", "").lower() == "websocket":
-        return await handle_websocket(request)
-    return await handle_http(request)
-
-app = web.Application()
-app.router.add_route("*", "/{path:.*}", handle_request)
-if __name__ == "__main__":
-    web.run_app(app, host="0.0.0.0", port=9222, print=None)
-'''
-        # Write proxy script
-        write_cmd = f"cat > /tmp/cdp_proxy.py << 'CDPPROXYSCRIPT'\n{proxy_script}\nCDPPROXYSCRIPT"
-        exec_shell(write_cmd)
-
-        # Install socat wrapper using sudo (password: password).
-        # 1. Backup real socat binary
-        # 2. Replace /usr/bin/socat with a bash wrapper that:
-        #    - Intercepts "socat tcp-listen:9222,..." and starts cdp_proxy.py instead
-        #    - Passes all other socat calls through to the real binary
-        socat_wrapper = (
-            '#!/bin/bash\n'
-            'REAL=/usr/bin/socat.real\n'
-            'for arg in "$@"; do\n'
-            '  case "$arg" in\n'
-            '    tcp-listen:9222*)\n'
-            '      nohup python3 /tmp/cdp_proxy.py >/tmp/cdp_proxy.log 2>&1 &\n'
-            '      for i in $(seq 1 50); do\n'
-            '        ss -tlnp 2>/dev/null | grep -q ":9222 " && exit 0\n'
-            '        sleep 0.2\n'
-            '      done\n'
-            '      exit 0\n'
-            '      ;;\n'
-            '  esac\n'
-            'done\n'
-            'exec "$REAL" "$@"\n'
+        exec_shell(
+            f"cat > /tmp/cdp_proxy.py << 'AGS_CDP_EOF'\n{_read_cdp_proxy_script()}\nAGS_CDP_EOF",
+            critical=True,
+            max_retries=3,
         )
-        # Write wrapper to /tmp first, then use sudo to install
-        exec_shell(f"cat > /tmp/socat_wrapper << 'SOCATWRAPPER'\n{socat_wrapper}SOCATWRAPPER")
-        exec_shell("chmod +x /tmp/socat_wrapper")
-        exec_shell("echo password | sudo -S cp /usr/bin/socat /usr/bin/socat.real")
-        exec_shell("echo password | sudo -S cp /tmp/socat_wrapper /usr/bin/socat")
-        exec_shell("echo password | sudo -S chmod +x /usr/bin/socat")
+        exec_shell(
+            f"cat > /tmp/socat_wrapper << 'AGS_CDP_EOF'\n{SOCAT_WRAPPER_SCRIPT}\nAGS_CDP_EOF",
+            critical=True,
+            max_retries=3,
+        )
+        exec_shell("chmod +x /tmp/socat_wrapper", critical=True, max_retries=2)
+
+        password = shlex.quote(os.environ.get("AGS_CLIENT_PASSWORD", "password"))
+        exec_shell(f"echo {password} | sudo -S cp /usr/bin/socat /usr/bin/socat.real || true")
+        exec_shell(f"echo {password} | sudo -S cp /tmp/socat_wrapper /usr/bin/socat", critical=True, max_retries=2)
+        exec_shell(f"echo {password} | sudo -S chmod +x /usr/bin/socat", critical=True, max_retries=2)
 
         # Verify wrapper is installed
         result = exec_shell("file /usr/bin/socat && file /usr/bin/socat.real")
@@ -933,6 +1013,9 @@ if __name__ == "__main__":
             self.envd_access_token = getattr(
                 self.sandbox, "_SandboxBase__envd_access_token", None
             )
+        self.traffic_access_token = getattr(self.sandbox, "traffic_access_token", None)
+        if not self.traffic_access_token:
+            self.traffic_access_token = getattr(self.sandbox, "trafficAccessToken", None)
 
         logger.info("AGS sandbox created with ID: %s", self.sandbox_id)
 
@@ -966,7 +1049,8 @@ if __name__ == "__main__":
 
     def revert_to_snapshot(self, path_to_vm: str, snapshot_name: str):
         """Revert by stopping and restarting the sandbox."""
-        logger.warning("AGS snapshot revert not supported, skipping...")
+        logger.info("AGS snapshot revert requested; replacing sandbox with a fresh instance.")
+        self.stop_emulator(path_to_vm)
 
     def stop_emulator(self, path_to_vm: str, region=None, *args, **kwargs):
         """Stop and kill the AGS sandbox."""
@@ -986,5 +1070,6 @@ if __name__ == "__main__":
                 self.sandbox = None
                 self.sandbox_id = None
                 self.envd_access_token = None
+                self.traffic_access_token = None
         else:
             logger.warning("stop_emulator called but sandbox is None")

--- a/examples/osworld-ags/overlay/OSWorld/requirements.txt
+++ b/examples/osworld-ags/overlay/OSWorld/requirements.txt
@@ -75,6 +75,6 @@ json_minify
 json_repair
 volcengine-python-sdk[ark]
 ui-tars>=0.4.2.2
-e2b>=2.13.2,<2.14.0
-e2b-code-interpreter>=2.4.1
+e2b>=2.24.0
+e2b-code-interpreter>=2.7.0
 aiohttp>=3.9.0

--- a/examples/osworld-ags/overlay/OSWorld/requirements.txt
+++ b/examples/osworld-ags/overlay/OSWorld/requirements.txt
@@ -75,5 +75,6 @@ json_minify
 json_repair
 volcengine-python-sdk[ark]
 ui-tars>=0.4.2.2
+e2b>=2.13.2,<2.14.0
 e2b-code-interpreter>=2.4.1
 aiohttp>=3.9.0

--- a/examples/osworld-ags/overlay/OSWorld/requirements.txt
+++ b/examples/osworld-ags/overlay/OSWorld/requirements.txt
@@ -75,6 +75,6 @@ json_minify
 json_repair
 volcengine-python-sdk[ark]
 ui-tars>=0.4.2.2
-e2b>=2.24.0
-e2b-code-interpreter>=2.7.0
+e2b>=2.24.0,<2.25.0
+e2b-code-interpreter>=2.7.0,<2.8.0
 aiohttp>=3.9.0

--- a/examples/osworld-ags/overlay/OSWorld/run_multienv.py
+++ b/examples/osworld-ags/overlay/OSWorld/run_multienv.py
@@ -13,7 +13,7 @@ import sys
 import signal
 import time
 from typing import List
-from multiprocessing import Process, Manager
+from multiprocessing import Process, Manager, Queue
 from multiprocessing import current_process
 import lib_run_single
 from desktop_env.desktop_env import DesktopEnv
@@ -104,6 +104,7 @@ log_level = getattr(logging, args.log_level.upper())
 logger.setLevel(log_level)
 
 datetime_str: str = datetime.datetime.now().strftime("%Y%m%d@%H%M%S")
+os.makedirs("logs", exist_ok=True)
 
 file_handler = logging.FileHandler(
     os.path.join("logs", "normal-{:}.log".format(datetime_str)), encoding="utf-8"
@@ -353,6 +354,8 @@ def test(args: argparse.Namespace, test_all_meta: dict) -> None:
     logger.info("Args: %s", args)
     all_tasks = distribute_tasks(test_all_meta)
     logger.info(f"Total tasks: {len(all_tasks)}")
+    max_worker_restarts = int(os.environ.get("OSWORLD_MAX_WORKER_RESTARTS", "2"))
+    worker_restarts = {}
     with Manager() as manager:
         shared_scores = manager.list()
         task_queue = manager.Queue()
@@ -375,6 +378,12 @@ def test(args: argparse.Namespace, test_all_meta: dict) -> None:
                 alive_count = 0
                 for idx, p in enumerate(processes):
                     if not p.is_alive():
+                        restart_count = worker_restarts.get(idx, 0)
+                        if restart_count >= max_worker_restarts:
+                            raise RuntimeError(
+                                f"Process {p.name} died and reached restart limit {max_worker_restarts}"
+                            )
+                        worker_restarts[idx] = restart_count + 1
                         logger.warning(f"Process {p.name} died, restarting...")
                         new_p = Process(
                             target=run_env_tasks,


### PR DESCRIPTION
## Summary

This PR fixes the OSWorld AGS cookbook overlay so the AGS provider can run OSWorld tasks more reliably with the standard runner.

Key changes:

- Move the CDP bridge script into `desktop_env/providers/ags/cdp_proxy.py` instead of embedding it as a large inline string in `provider.py`.
- Keep the sandbox-side CDP bridge dependency-free at runtime by using Python standard library only.
- Make AGS snapshot reset semantics explicit: AGS does not expose OSWorld VM snapshots, so `revert_to_snapshot()` replaces the current sandbox instead of silently reusing it.
- Ensure local proxy cleanup is scoped to the current `AGSProvider` instance before the next sandbox is created.
- Cap `e2b` / `e2b-code-interpreter` versions so `ark_` AGS API keys work out of the box; document that users can switch the key prefix to `e2b_` if they manually upgrade SDK versions.
- Update README / README_zh to reflect the current overlay files, auth behavior, and sandbox reset behavior.
- Make `make setup` idempotent when the OSWorld virtualenv already exists.
- Add small runner compatibility fixes used by the AGS overlay, including `vm_machine` and worker restart guard.
