### PR TITLE
feat: add AGS Docker-in-Docker cookbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ enhanced_demo_output/
 *.csv
 !package.json
 !package-lock.json
+!examples/dind/tool-custom-configuration.hk.json
 # pnpm-lock.yaml is not matched by *.json, but kept here to guard against
 # any future *.yaml or catch-all rule that might exclude it.
 !pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ You can also enter an example directory directly and run its local `make setup` 
 | `custom-image-go-sdk` | Go | Custom-image / custom-tool startup |
 | `data-analysis` | Python + code sandbox | Multi-context data workflow |
 | [`deployment-cookbook`](./examples/deployment-cookbook/README.md) | agr CLI + Markdown + Python | Deployment, scaling, lifecycle, affinity, native MCP server, and persistent agent workspace scenarios |
+| `dind` | Docker + Compose + envd + Harbor + agr | Self-starting DinD Sandbox that runs a real Terminal-Bench Compose task with Harbor Oracle |
 | `envd-oci-env` | Bash + Docker + agr | Preserve OCI image environment variables when envd is PID 1 |
 | `harness-nix-volume` | Nix + custom image + image volume | Self-contained Harness dependency mount |
 | `html-processing` | Python + browser/code sandboxes | Dual-sandbox HTML pipeline |

--- a/README_zh.md
+++ b/README_zh.md
@@ -84,6 +84,7 @@ make example-run EXAMPLE=mini-rl
 | `custom-image-go-sdk` | Go | 自定义镜像 / 自定义工具启动 |
 | `data-analysis` | Python + 代码沙箱 | 多 Context 数据分析 |
 | `deployment-cookbook` | agr CLI + Markdown | Deployment、伸缩、生命周期、亲和性与长驻 Agent 工作区场景 |
+| `dind` | Docker + Compose + envd + Harbor + agr | 自启动 DinD 沙箱，并通过 Harbor Oracle 运行真实的 Terminal-Bench Compose 任务 |
 | `envd-oci-env` | Bash + Docker + agr | envd 作为 PID 1 时保留 OCI 镜像环境变量 |
 | `harness-nix-volume` | Nix + 自定义镜像 + 镜像卷 | 自包含 Harness 依赖挂载 |
 | `html-processing` | Python + Browser/Code 双沙箱 | HTML 协作处理 |

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,7 @@ This directory contains runnable AGS examples. Each example keeps its own README
 - `browser-agent` — browser automation agent with an OpenAI-compatible LLM backend
 - `data-analysis` — multi-context data workflow with multiple generated artifacts
 - [`deployment-cookbook`](./deployment-cookbook/README.md) — Deployment management with `agr`, from httpbin basics and a native MCP server to a persistent agent workspace
+- `dind` — self-starting Docker-in-Docker Tool that runs a real Terminal-Bench Compose task with Harbor Oracle
 - `envd-oci-env` — preserve OCI image environment variables when envd is PID 1
 - `harness-nix-volume` — package a self-contained Harness runtime with Nix and mount it into a custom image
 - `mini-swe-agent` — SWE-bench evaluation with AGS SWE sandbox and SWE-ReX runtime
@@ -46,6 +47,7 @@ Some heavier or externally overlaid examples are exceptions, but they should sti
 | `custom-image-go-sdk` | advanced | Go | `make run` | Requires custom tool/image setup in AGS account |
 | `data-analysis` | advanced | Python + code sandbox | `make run` | Generates multiple output files |
 | [`deployment-cookbook`](./deployment-cookbook/README.md) | advanced | agr CLI + Markdown + Python | Follow a scenario README | Covers deployment, scaling, lifecycle, affinity, a native MCP server, and a persistent agent workspace |
+| `dind` | advanced | Docker + Compose + envd + Harbor + agr | `make run` | Creates a DinD Tool and runs a real Terminal-Bench Compose task with Harbor Oracle |
 | `envd-oci-env` | advanced | Bash + Docker + agr | `make run` | Reproduces and validates envd OCI environment inheritance |
 | `harness-nix-volume` | advanced | Nix + custom image + image volume | `make build-images` then `make run` | Mount self-contained Harness dependencies into a main image |
 | `html-processing` | starter | Python + browser/code sandboxes | `make run` | Good visual intro to dual-sandbox flow |

--- a/examples/README_zh.md
+++ b/examples/README_zh.md
@@ -15,6 +15,7 @@
 - `browser-agent` —— 基于 OpenAI-compatible LLM 的浏览器自动化 Agent
 - `data-analysis` —— 多 Context 数据工作流，生成多个产物
 - `deployment-cookbook` —— 使用 `agr` 管理 Deployment，从 httpbin 基础到长驻 Agent 工作区
+- `dind` —— 自启动 Docker-in-Docker Tool，并通过 Harbor Oracle 运行真实的 Terminal-Bench Compose 任务
 - `envd-oci-env` —— envd 作为 PID 1 时保留 OCI 镜像环境变量
 - `harness-nix-volume` —— 用 Nix 打包自包含 Harness 运行时，并挂载到自定义主镜像
 - `mini-swe-agent` —— 基于 AGS SWE Sandbox 和 SWE-ReX runtime 运行 SWE-bench 评测
@@ -46,6 +47,7 @@
 | `custom-image-go-sdk` | 进阶 | Go | `make run` | 依赖 AGS 账号中的自定义工具 / 镜像配置 |
 | `data-analysis` | 进阶 | Python + 代码沙箱 | `make run` | 会生成多种图表与报告文件 |
 | `deployment-cookbook` | 进阶 | agr CLI + Markdown | 按场景 README 操作 | 涵盖部署、伸缩、生命周期、亲和性与长驻 Agent 工作区 |
+| `dind` | 进阶 | Docker + Compose + envd + Harbor + agr | `make run` | 创建 DinD Tool，并通过 Harbor Oracle 运行真实的 Terminal-Bench Compose 任务 |
 | `envd-oci-env` | 进阶 | Bash + Docker + agr | `make run` | 复现并验证 envd 的 OCI 环境变量继承 |
 | `harness-nix-volume` | 进阶 | Nix + 自定义镜像 + 镜像卷 | `make build-images` 后 `make run` | 将自包含 Harness 依赖挂载进主镜像 |
 | `html-processing` | 入门 | Python + 浏览器/代码双沙箱 | `make run` | 适合作为双沙箱协作的直观起点 |

--- a/examples/dind/.env.example
+++ b/examples/dind/.env.example
@@ -1,0 +1,9 @@
+AGS_REGION=ap-hongkong
+AGS_TOOL_NAME=ags-dind-v1-0-0
+AGS_INSTANCE_TIMEOUT=90m
+AGS_EXEC_USER=root
+
+# Leave these empty when agr already has credentials configured locally.
+TENCENTCLOUD_SECRET_ID=
+TENCENTCLOUD_SECRET_KEY=
+TENCENTCLOUD_TOKEN=

--- a/examples/dind/.gitignore
+++ b/examples/dind/.gitignore
@@ -1,0 +1,3 @@
+.env
+.instance-id
+.tool-id

--- a/examples/dind/Makefile
+++ b/examples/dind/Makefile
@@ -1,0 +1,63 @@
+SHELL := /bin/bash
+
+ifneq (,$(wildcard .env))
+include .env
+export
+endif
+
+REPO_ROOT := $(abspath ../..)
+DIND_DOCKERFILE := $(CURDIR)/image/Dockerfile
+ENVD_BUILD_REVISION ?= $(shell git -C $(REPO_ROOT) log -1 --format=%H -- utils/envd/versions/0.5.14-oci)
+
+IMAGE_GZ ?= ccr.ccs.tencentyun.com/ags-image/dind:v1.0.0
+IMAGE_HK ?= hkccr.ccs.tencentyun.com/ags-image/dind:v1.0.0
+AGR_BIN ?= agr
+
+.PHONY: setup build-image push-images create-tool start harbor-oracle run cleanup
+
+setup:
+	@command -v "$(AGR_BIN)" >/dev/null || { \
+		echo "agr is required; install it from https://github.com/TencentCloudAgentRuntime/ags-cli"; \
+		exit 1; \
+	}
+	@current_version="$$($(AGR_BIN) version -o json --jq '.Data.Version')"; \
+	update_available="$$($(AGR_BIN) update --check -o json --jq '.Data.update_available')" || { \
+		echo "Unable to check the latest agr version."; \
+		exit 1; \
+	}; \
+	if [[ "$$update_available" == "true" ]]; then \
+		latest_version="$$($(AGR_BIN) update --check -o json --jq '.Data.latest')"; \
+		echo "agr $$current_version is outdated; latest is v$${latest_version#v}."; \
+		echo "Upgrade with: curl -fsSL https://github.com/TencentCloudAgentRuntime/ags-cli/releases/latest/download/install.sh | sh"; \
+		exit 1; \
+	fi; \
+	echo "agr $$current_version is the latest version."
+	@test -f .env || cp .env.example .env
+	@echo "Ready. Review .env before creating cloud resources."
+
+build-image:
+	docker buildx build --platform linux/amd64 --load \
+		--build-arg ENVD_BUILD_REVISION=$(ENVD_BUILD_REVISION) \
+		-f $(DIND_DOCKERFILE) -t $(IMAGE_HK) $(REPO_ROOT)
+
+push-images:
+	docker buildx build --platform linux/amd64 --provenance=true \
+		--build-arg ENVD_BUILD_REVISION=$(ENVD_BUILD_REVISION) \
+		-f $(DIND_DOCKERFILE) -t $(IMAGE_GZ) -t $(IMAGE_HK) --push $(REPO_ROOT)
+
+create-tool:
+	./scripts/create-tool.sh
+
+start:
+	./scripts/start-instance.sh
+
+harbor-oracle:
+	./scripts/run-harbor-oracle.sh
+
+run:
+	./scripts/create-tool.sh
+	./scripts/start-instance.sh
+	./scripts/run-harbor-oracle.sh
+
+cleanup:
+	./scripts/cleanup.sh

--- a/examples/dind/README.md
+++ b/examples/dind/README.md
@@ -1,0 +1,98 @@
+# Run Docker-in-Docker on AGS
+
+This example provides a DinD image that can be used directly by an AGS Custom Tool. Once the Sandbox is ready, `dockerd`, `docker compose`, and `envd` are available immediately. Clients can upload files and execute commands as `root` without manually mounting storage or starting a daemon.
+
+Public images:
+
+- Guangzhou: `ccr.ccs.tencentyun.com/ags-image/dind:v1.0.0`
+- Hong Kong: `hkccr.ccs.tencentyun.com/ags-image/dind:v1.0.0`
+- OCI image index: `sha256:b1332e5cfaeaa335e1c3aae69ffd8a84b42dd78e014247e972d56003338595d3`
+- Architecture: `linux/amd64`
+- Build file: [`image/Dockerfile`](./image/Dockerfile)
+
+The image is based on the official `docker:29.3.1-dind` image. It contains Docker Engine, Docker CLI, BuildKit, Docker Compose 5.1.1, Bash, util-linux, and [`envd` 0.5.14-oci](../../utils/envd/versions/0.5.14-oci/) built from this repository. This envd distribution preserves the image startup environment and default working directory.
+
+The [`image/entrypoint.sh`](./image/entrypoint.sh) wrapper detects the cgroup layout, mounts the AGS-provided `/dev/vda` at `/mnt`, and bind-mounts Docker and containerd data onto that disk. It then starts and supervises `dockerd` and `envd` as `root`. The readiness probe succeeds only after both are available.
+
+To customize the image, build it from this directory:
+
+```bash
+make build-image
+```
+
+Push the result to your own TCR/CCR repository, or use one of the public images above.
+
+## Prerequisites
+
+- Use the latest version of `agr`.
+- Configure Tencent Cloud credentials.
+- This example uses Hong Kong with `PUBLIC` networking because it downloads Harbor and example images from GitHub, PyPI, and Docker Hub.
+
+## 1. Create the Tool and Sandbox
+
+Run the setup check. It verifies that `agr` is installed and up to date, then creates `.env` from `.env.example` if needed:
+
+```bash
+make setup
+```
+
+Review `.env` before continuing. If `agr` does not already have Tencent Cloud credentials configured locally, set `TENCENTCLOUD_SECRET_ID` and `TENCENTCLOUD_SECRET_KEY`; also set `TENCENTCLOUD_TOKEN` when using temporary credentials. [`tool-custom-configuration.hk.json`](./tool-custom-configuration.hk.json) anonymously pulls the public Hong Kong image at a pinned digest and requests 4 CPUs, 8 GiB memory, and a 20 GiB disk. It does not require a `RoleArn`.
+
+Create the Tool and Sandbox:
+
+```bash
+make create-tool
+make start
+```
+
+The Tool ID and Instance ID are stored in `.tool-id` and `.instance-id`. `make start` waits for the envd data plane, then checks that the default user is `root`, the default directory is `/workspace`, and Docker Engine and Compose are ready.
+
+You can also run a command directly:
+
+```bash
+agr --region ap-hongkong instance exec "$(cat .instance-id)" \
+  --user root -- docker compose version
+```
+
+## 2. Run a real Terminal-Bench Compose task with Harbor Oracle
+
+This example uses Harbor v0.22.0 to run the [`intrastat-meldung`](https://github.com/harbor-framework/terminal-bench/tree/v3.0.0/tasks/intrastat-meldung) task from Terminal-Bench 3.0.0 with Harbor's built-in `oracle` agent:
+
+```bash
+make harbor-oracle
+```
+
+[`run-harbor-oracle.sh`](./scripts/run-harbor-oracle.sh) uploads a runner through envd. Inside the Sandbox, the runner installs Git, Python, and `uv`, checks out only this task, and invokes:
+
+```bash
+harbor trial start \
+  --path terminal-bench/tasks/intrastat-meldung \
+  --agent oracle \
+  --env docker
+```
+
+Harbor then manages the complete task lifecycle on the inner Docker daemon:
+
+1. Build the task's original images and start its six-service Compose environment: `main`, `odoo`, `compliance-hub`, `idev`, `services`, and `dms`.
+2. Wait for the services to become healthy, copy the task's `solution/` into `main`, and run the official Oracle solution. The Oracle makes live API calls to the five sidecars and produces the task artifacts.
+3. Collect the artifacts declared in `task.toml` from `main` and `compliance-hub`.
+4. Build the original `tests/Dockerfile`, run the verifier in the separate environment declared by `task.toml`, and require reward `1.0`.
+5. Remove the Compose containers, network, and volumes, then write the structured trial result under `/mnt/ags-dind/harbor-oracle-intrastat-meldung-v3.0.0/trials/`.
+
+This single run validates Harbor's native Compose startup and healthchecks, service DNS, shared volumes, cross-service artifact collection, Oracle execution, separate verifier, and resource cleanup on the AGS DinD image.
+
+The final line on success is:
+
+```text
+Harbor Oracle validation: PASS (.../result.json)
+```
+
+On a first run, `make run` creates the Tool, starts the Sandbox, and runs this Oracle validation in one sequence.
+
+## Cleanup
+
+Delete the Instance and Tool created by this example:
+
+```bash
+make cleanup
+```

--- a/examples/dind/README_zh.md
+++ b/examples/dind/README_zh.md
@@ -1,0 +1,98 @@
+# 在 AGS 中运行 Docker-in-Docker
+
+本示例提供一个可直接用于 AGS Custom Tool 的 DinD 镜像。Sandbox 启动完成后，`dockerd`、`docker compose` 和 `envd` 已经就绪，调用方可以立即上传文件并以 `root` 执行命令，不需要再手工挂盘或启动 daemon。
+
+公开镜像：
+
+- 广州：`ccr.ccs.tencentyun.com/ags-image/dind:v1.0.0`
+- 香港：`hkccr.ccs.tencentyun.com/ags-image/dind:v1.0.0`
+- OCI image index：`sha256:b1332e5cfaeaa335e1c3aae69ffd8a84b42dd78e014247e972d56003338595d3`
+- 架构：`linux/amd64`
+- 构建文件：[`image/Dockerfile`](./image/Dockerfile)
+
+镜像基于官方 `docker:29.3.1-dind`，包含 Docker Engine、Docker CLI、BuildKit、Docker Compose 5.1.1、`bash`、`util-linux`，以及从本仓库源码构建的 [`envd` 0.5.14-oci](../../utils/envd/versions/0.5.14-oci/)。
+
+启动脚本 [`image/entrypoint.sh`](./image/entrypoint.sh) 会自动识别 cgroup，将 AGS 注入的 `/dev/vda` 挂载到 `/mnt`，再把 Docker 和 containerd 的数据目录 bind mount 到数据盘。随后它以 `root` 启动并监管 `dockerd` 与 `envd`；只有两者都可用后 readiness probe 才会通过。
+
+如果需要构建镜像，可以在本目录执行，并上传到个人的 CCR 或 TCR 上使用：
+
+```bash
+make build-image
+```
+
+构建结果可以推送到自己的 TCR/CCR，也可以直接使用上面的公开镜像。
+
+## 前置条件
+
+- 使用最新版 `agr`。
+- 已配置腾讯云凭证。
+- 本示例选择香港 `PUBLIC` 网络，因为需要从 GitHub、PyPI 和 Docker Hub 下载 Harbor 及示例镜像。
+
+## 1. 创建 Tool 和 Sandbox
+
+运行初始化检查。它会确认 `agr` 已安装且为最新版本，并在需要时从 `.env.example` 创建 `.env`：
+
+```bash
+make setup
+```
+
+继续前请检查 `.env`。如果本机的 `agr` 尚未配置腾讯云凭证，请填写 `TENCENTCLOUD_SECRET_ID` 和 `TENCENTCLOUD_SECRET_KEY`；使用临时凭证时同时填写 `TENCENTCLOUD_TOKEN`。[`tool-custom-configuration.hk.json`](./tool-custom-configuration.hk.json) 通过固定 digest 匿名拉取香港公开镜像，并申请 4 CPU、8 GiB 内存和 20 GiB 磁盘，不需要 `RoleArn`。
+
+创建 Tool 和 Sandbox：
+
+```bash
+make create-tool
+make start
+```
+
+Tool ID 和 Instance ID 会分别写入 `.tool-id` 与 `.instance-id`。`make start` 会等待 envd 数据面可用，并检查默认用户为 `root`、默认目录为 `/workspace`，以及 Docker Engine 和 Compose 是否已经就绪。
+
+也可以直接执行命令：
+
+```bash
+agr --region ap-hongkong instance exec "$(cat .instance-id)" \
+  --user root -- docker compose version
+```
+
+## 2. 使用 Harbor Oracle 运行真实的 Terminal-Bench Compose 任务
+
+本示例使用 Harbor v0.22.0 内置的 `oracle` agent，运行 Terminal-Bench 3.0.0 的真实任务 [`intrastat-meldung`](https://github.com/harbor-framework/terminal-bench/tree/v3.0.0/tasks/intrastat-meldung)：
+
+```bash
+make harbor-oracle
+```
+
+[`run-harbor-oracle.sh`](./scripts/run-harbor-oracle.sh) 先通过 envd 上传 runner。runner 在 Sandbox 内安装 Git、Python 和 `uv`，只检出这个任务，然后执行：
+
+```bash
+harbor trial start \
+  --path terminal-bench/tasks/intrastat-meldung \
+  --agent oracle \
+  --env docker
+```
+
+接下来由 Harbor 通过内层 Docker daemon 管理完整的任务生命周期：
+
+1. 使用任务原始的 Dockerfile 构建镜像，并启动由 `main`、`odoo`、`compliance-hub`、`idev`、`services` 和 `dms` 组成的六服务 Compose 环境。
+2. 等待各 service 健康，将任务的 `solution/` 复制到 `main`，并运行官方 Oracle。Oracle 实时调用五个 sidecar 的 API 完成任务并生成产物。
+3. 按照 `task.toml` 的声明，从 `main` 和 `compliance-hub` 收集 artifacts。
+4. 使用原始 `tests/Dockerfile` 构建 verifier，按照 `task.toml` 的声明在独立环境中执行验证，并要求 reward 为 `1.0`。
+5. 清理 Compose 容器、网络和卷，并将结构化结果写入 `/mnt/ags-dind/harbor-oracle-intrastat-meldung-v3.0.0/trials/`。
+
+这一个任务会实际验证 AGS DinD 镜像上的 Harbor 原生流程，包括 Compose 启动与 healthcheck、service DNS、共享卷、跨 service artifact 收集、Oracle 执行、独立 verifier 和资源清理。
+
+成功时最后会输出：
+
+```text
+Harbor Oracle validation: PASS (.../result.json)
+```
+
+首次使用时，也可以执行 `make run`，连续完成 Tool 创建、Sandbox 启动和 Oracle 验证。
+
+## 清理
+
+完成后删除本示例创建的 Instance 和 Tool：
+
+```bash
+make cleanup
+```

--- a/examples/dind/image/Dockerfile
+++ b/examples/dind/image/Dockerfile
@@ -1,0 +1,52 @@
+ARG GO_IMAGE=golang:1.25.9-bookworm
+ARG BASE_IMAGE=docker:29.3.1-dind@sha256:686d2c5464787b0ca42420e0aa03a94fc9781ff9bf8b5ff947614b9fa4c3c3e0
+
+FROM ${GO_IMAGE} AS envd-builder
+
+ARG ENVD_BUILD_REVISION=unknown
+WORKDIR /workspace
+COPY utils/envd/versions/0.5.14-oci/src ./src
+COPY utils/envd/versions/0.5.14-oci/shared ./shared
+WORKDIR /workspace/src
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    go build \
+      -trimpath \
+      -buildvcs=false \
+      -a \
+      -o /out/envd \
+      -ldflags "-X=main.commitSHA=${ENVD_BUILD_REVISION} -s -w -buildid=" \
+      .
+
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Build the OCI-aware envd distribution from its vendored, auditable source.
+COPY --from=envd-builder --chmod=755 /out/envd /usr/bin/envd
+COPY --chmod=755 examples/dind/image/entrypoint.sh /usr/local/bin/ags-dind-entrypoint
+
+RUN apk add --no-cache bash util-linux \
+    && adduser -D -u 1000 -G docker user \
+    && mkdir -p /workspace \
+    && chown user:docker /workspace
+
+ENV DOCKER_HOST=unix:///var/run/docker.sock \
+    DOCKER_TLS_CERTDIR="" \
+    ENVD_DISTRIBUTION=0.5.14-oci \
+    TINI_SUBREAPER=1 \
+    DIND_BLOCK_DEVICE=/dev/vda \
+    DIND_MOUNT_POINT=/mnt \
+    DIND_STATE_DIR=/mnt/dind \
+    DIND_REQUIRE_EXTERNAL_STORAGE=1 \
+    DIND_READY_TIMEOUT_SECONDS=180 \
+    ENVD_PORT=49983
+
+EXPOSE 49983
+WORKDIR /workspace
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=180s --retries=3 \
+    CMD docker info >/dev/null 2>&1 && wget -q -O /dev/null "http://127.0.0.1:${ENVD_PORT}/health"
+
+STOPSIGNAL SIGTERM
+ENTRYPOINT ["/usr/local/bin/ags-dind-entrypoint"]
+CMD []

--- a/examples/dind/image/Dockerfile.dockerignore
+++ b/examples/dind/image/Dockerfile.dockerignore
@@ -1,0 +1,13 @@
+**
+!examples/
+!examples/dind/
+!examples/dind/image/
+!examples/dind/image/entrypoint.sh
+!utils/
+!utils/envd/
+!utils/envd/versions/
+!utils/envd/versions/0.5.14-oci/
+!utils/envd/versions/0.5.14-oci/src/
+!utils/envd/versions/0.5.14-oci/src/**
+!utils/envd/versions/0.5.14-oci/shared/
+!utils/envd/versions/0.5.14-oci/shared/**

--- a/examples/dind/image/entrypoint.sh
+++ b/examples/dind/image/entrypoint.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+log() {
+  printf '[ags-dind] %s\n' "$*"
+}
+
+fatal() {
+  log "ERROR: $*"
+  exit 1
+}
+
+is_mountpoint() {
+  mountpoint -q "$1"
+}
+
+bind_to_data_disk() {
+  local source="$1"
+  local target="$2"
+
+  mkdir -p "${source}" "${target}"
+  # docker:dind declares /var/lib/docker as a VOLUME. The outer runtime can
+  # therefore mount an anonymous volume there before this script starts.
+  if [[ "$(stat -Lc '%d:%i' "${source}")" != "$(stat -Lc '%d:%i' "${target}")" ]]; then
+    mount --bind "${source}" "${target}"
+  fi
+}
+
+prepare_devices_cgroup() {
+  if [[ -f /sys/fs/cgroup/cgroup.controllers ]]; then
+    log "cgroup v2 detected"
+    return
+  fi
+
+  mkdir -p /sys/fs/cgroup/devices
+  if ! is_mountpoint /sys/fs/cgroup/devices; then
+    log "mounting the cgroup v1 devices controller"
+    mount -t cgroup -o devices cgroup /sys/fs/cgroup/devices
+  fi
+}
+
+prepare_external_storage() {
+  local mount_point="${DIND_MOUNT_POINT}"
+  local block_device="${DIND_BLOCK_DEVICE}"
+  local state_dir="${DIND_STATE_DIR}"
+
+  mkdir -p "${mount_point}"
+  if is_mountpoint "${mount_point}"; then
+    log "using storage already mounted at ${mount_point}"
+  elif [[ -b "${block_device}" ]]; then
+    log "mounting ${block_device} at ${mount_point}"
+    mount "${block_device}" "${mount_point}"
+  elif [[ "${DIND_REQUIRE_EXTERNAL_STORAGE}" == "1" ]]; then
+    fatal "${mount_point} is not mounted and ${block_device} is unavailable"
+  else
+    log "WARNING: using the outer container filesystem"
+    state_dir="/var/lib/ags-dind"
+  fi
+
+  # Keep inner writable layers off the outer container's overlay filesystem.
+  bind_to_data_disk "${state_dir}/containerd" /var/lib/containerd
+  bind_to_data_disk "${state_dir}/docker" /var/lib/docker
+
+  log "Docker and containerd state are backed by ${state_dir}"
+}
+
+wait_for_docker() {
+  local deadline=$((SECONDS + DIND_READY_TIMEOUT_SECONDS))
+  until docker info >/dev/null 2>&1; do
+    if ! kill -0 "${dockerd_pid}" 2>/dev/null; then
+      wait "${dockerd_pid}" || true
+      fatal "dockerd exited before becoming ready"
+    fi
+    if (( SECONDS >= deadline )); then
+      fatal "dockerd was not ready within ${DIND_READY_TIMEOUT_SECONDS}s"
+    fi
+    sleep 1
+  done
+}
+
+wait_for_envd() {
+  local deadline=$((SECONDS + DIND_READY_TIMEOUT_SECONDS))
+  until wget -q -O /dev/null "http://127.0.0.1:${ENVD_PORT}/health"; do
+    if ! kill -0 "${envd_pid}" 2>/dev/null; then
+      wait "${envd_pid}" || true
+      fatal "envd exited before becoming ready"
+    fi
+    if (( SECONDS >= deadline )); then
+      fatal "envd was not ready within ${DIND_READY_TIMEOUT_SECONDS}s"
+    fi
+    sleep 1
+  done
+}
+
+shutdown_children() {
+  local pid
+  for pid in "${envd_pid:-}" "${dockerd_pid:-}"; do
+    if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+      kill -TERM "${pid}" 2>/dev/null || true
+    fi
+  done
+
+  local deadline=$((SECONDS + 20))
+  while (( SECONDS < deadline )); do
+    if ! kill -0 "${envd_pid:-0}" 2>/dev/null \
+      && ! kill -0 "${dockerd_pid:-0}" 2>/dev/null; then
+      break
+    fi
+    sleep 1
+  done
+
+  for pid in "${envd_pid:-}" "${dockerd_pid:-}"; do
+    if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+      kill -KILL "${pid}" 2>/dev/null || true
+    fi
+    if [[ -n "${pid}" ]]; then
+      wait "${pid}" 2>/dev/null || true
+    fi
+  done
+}
+
+on_signal() {
+  log "received termination signal"
+  shutdown_children
+  exit 0
+}
+
+if [[ "$(id -u)" != "0" ]]; then
+  fatal "the AGS DinD image must run as root"
+fi
+
+trap on_signal INT TERM HUP
+
+prepare_devices_cgroup
+prepare_external_storage
+rm -f /var/run/docker.sock
+
+log "starting dockerd"
+/usr/local/bin/dockerd-entrypoint.sh \
+  dockerd \
+  --host="${DOCKER_HOST}" \
+  --data-root=/var/lib/docker \
+  "$@" &
+dockerd_pid=$!
+
+wait_for_docker
+log "dockerd is ready: driver=$(docker info --format '{{.Driver}}')"
+
+log "starting envd on port ${ENVD_PORT}"
+/usr/bin/envd -port "${ENVD_PORT}" &
+envd_pid=$!
+wait_for_envd
+log "envd is ready"
+
+set +e
+wait -n "${dockerd_pid}" "${envd_pid}"
+exit_status=$?
+set -e
+
+log "a managed process exited with status ${exit_status}"
+shutdown_children
+exit "${exit_status}"

--- a/examples/dind/scripts/cleanup.sh
+++ b/examples/dind/scripts/cleanup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# shellcheck source=common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+require_command "${AGR_BIN}"
+
+instance_id="${AGS_INSTANCE_ID:-}"
+if [[ -z "${instance_id}" && -f "${ROOT_DIR}/.instance-id" ]]; then
+  instance_id="$(tr -d '[:space:]' < "${ROOT_DIR}/.instance-id")"
+fi
+if [[ -n "${instance_id}" ]]; then
+  print_agr_command instance delete "${instance_id}" --yes --ignore-not-found
+  agr_cli instance delete "${instance_id}" --yes --ignore-not-found
+  run_command rm -f "${ROOT_DIR}/.instance-id"
+else
+  printf 'No Sandbox ID found; skipping Sandbox deletion.\n'
+fi
+
+tool_id="${AGS_TOOL_ID:-}"
+if [[ -z "${tool_id}" && -f "${ROOT_DIR}/.tool-id" ]]; then
+  tool_id="$(tr -d '[:space:]' < "${ROOT_DIR}/.tool-id")"
+fi
+if [[ -n "${tool_id}" ]]; then
+  print_agr_command tool delete "${tool_id}" --yes
+  agr_cli tool delete "${tool_id}" --yes
+  run_command rm -f "${ROOT_DIR}/.tool-id"
+else
+  printf 'No Tool ID found; skipping Tool deletion.\n'
+fi

--- a/examples/dind/scripts/common.sh
+++ b/examples/dind/scripts/common.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ -f "${ROOT_DIR}/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${ROOT_DIR}/.env"
+  set +a
+fi
+
+AGR_BIN="${AGR_BIN:-agr}"
+AGS_REGION="${AGS_REGION:-ap-hongkong}"
+AGS_EXEC_USER="${AGS_EXEC_USER:-root}"
+AGS_INSTANCE_TIMEOUT="${AGS_INSTANCE_TIMEOUT:-90m}"
+
+AGR_GLOBAL_ARGS=(--region "${AGS_REGION}" --non-interactive)
+if [[ -n "${AGR_CONFIG:-}" ]]; then
+  AGR_GLOBAL_ARGS+=(--config "${AGR_CONFIG}")
+fi
+if [[ -n "${AGS_CLOUD_ENDPOINT:-}" ]]; then
+  AGR_GLOBAL_ARGS+=(--cloud-endpoint "${AGS_CLOUD_ENDPOINT}")
+fi
+if [[ -n "${AGS_DATA_DOMAIN:-}" ]]; then
+  AGR_GLOBAL_ARGS+=(--domain "${AGS_DATA_DOMAIN}")
+fi
+if [[ -n "${TENCENTCLOUD_SECRET_ID:-}" && -n "${TENCENTCLOUD_SECRET_KEY:-}" ]]; then
+  AGR_GLOBAL_ARGS+=(
+    --secret-id "${TENCENTCLOUD_SECRET_ID}"
+    --secret-key "${TENCENTCLOUD_SECRET_KEY}"
+  )
+fi
+if [[ -n "${TENCENTCLOUD_TOKEN:-}" ]]; then
+  AGR_GLOBAL_ARGS+=(--token "${TENCENTCLOUD_TOKEN}")
+fi
+
+agr_cli() {
+  "${AGR_BIN}" "${AGR_GLOBAL_ARGS[@]}" "$@"
+}
+
+print_command() {
+  local argument
+  if [[ -z "${NO_COLOR:-}" ]]; then
+    printf '\033[1;36m' >&2
+  fi
+  printf '$' >&2
+  for argument in "$@"; do
+    if [[ "${argument}" == *$'\n'* ]]; then
+      argument='<multiline argument>'
+    elif (( ${#argument} > 180 )); then
+      argument="${argument:0:160}..."
+    fi
+    printf ' %q' "${argument}" >&2
+  done
+  if [[ -z "${NO_COLOR:-}" ]]; then
+    printf '\033[0m' >&2
+  fi
+  printf '\n' >&2
+}
+
+print_command_line() {
+  if [[ -z "${NO_COLOR:-}" ]]; then
+    printf '\033[1;36m' >&2
+  fi
+  printf '%s' "$1" >&2
+  if [[ -z "${NO_COLOR:-}" ]]; then
+    printf '\033[0m' >&2
+  fi
+  printf '\n' >&2
+}
+
+# Print the useful, non-secret portion of an agr invocation. Authentication is
+# supplied by agr_cli from .env, but credentials must never be copied to logs.
+print_agr_command() {
+  print_command "${AGR_BIN}" --region "${AGS_REGION}" --non-interactive "$@"
+}
+
+run_command() {
+  print_command "$@"
+  "$@"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf 'required command is missing: %s\n' "$1" >&2
+    exit 1
+  }
+}
+
+require_agr_storage_support() {
+  local version
+  local major
+  local minor
+  local patch
+  version="$("${AGR_BIN}" version | awk 'NR == 1 {print $3}')"
+  if [[ "${version}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+    major="${BASH_REMATCH[1]}"
+    minor="${BASH_REMATCH[2]}"
+    patch="${BASH_REMATCH[3]}"
+    if (( major == 0 && (minor < 6 || (minor == 6 && patch < 6)) )); then
+      printf 'agr >= v0.6.6 is required; found %s\n' "${version}" >&2
+      exit 1
+    fi
+  fi
+}
+
+read_id() {
+  local environment_name="$1"
+  local state_file="$2"
+  local value="${!environment_name:-}"
+  if [[ -z "${value}" && -f "${state_file}" ]]; then
+    value="$(tr -d '[:space:]' < "${state_file}")"
+  fi
+  [[ -n "${value}" ]] || {
+    printf '%s is unset and %s does not exist\n' "${environment_name}" "${state_file}" >&2
+    exit 1
+  }
+  printf '%s' "${value}"
+}

--- a/examples/dind/scripts/create-tool.sh
+++ b/examples/dind/scripts/create-tool.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# shellcheck source=common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+require_command "${AGR_BIN}"
+require_agr_storage_support
+
+tool_name_prefix="${AGS_TOOL_NAME:-ags-dind-v1-0-0}"
+tool_name="${tool_name_prefix}-$(date +%Y%m%d%H%M%S)-$$"
+config_file="${ROOT_DIR}/tool-custom-configuration.hk.json"
+
+printf 'Creating Tool %s in %s\n' "${tool_name}" "${AGS_REGION}"
+print_agr_command tool create \
+  --tool-name "${tool_name}" \
+  --tool-type custom \
+  --description "Self-starting Docker-in-Docker sandbox with envd" \
+  --default-timeout 2h \
+  --network-configuration '{"NetworkMode":"PUBLIC"}' \
+  --custom-configuration "@${config_file}" \
+  --wait \
+  -o json \
+  --jq '.Data.ToolId'
+if ! tool_id="$(
+  agr_cli tool create \
+    --tool-name "${tool_name}" \
+    --tool-type custom \
+    --description "Self-starting Docker-in-Docker sandbox with envd" \
+    --default-timeout 2h \
+    --network-configuration '{"NetworkMode":"PUBLIC"}' \
+    --custom-configuration "@${config_file}" \
+    --wait \
+    -o json \
+    --jq '.Data.ToolId'
+)"; then
+  printf '%s\n' "${tool_id}" >&2
+  exit 1
+fi
+
+printf '%s\n' "${tool_id}" > "${ROOT_DIR}/.tool-id"
+printf 'Tool ID: %s\n' "${tool_id}"
+printf 'Saved to %s\n' "${ROOT_DIR}/.tool-id"

--- a/examples/dind/scripts/run-harbor-oracle-in-sandbox.sh
+++ b/examples/dind/scripts/run-harbor-oracle-in-sandbox.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+harbor_version="${HARBOR_VERSION:-0.22.0}"
+tb3_ref="${TB3_REF:-v3.0.0}"
+tb3_task="${TB3_TASK:-intrastat-meldung}"
+base_dir="/mnt/ags-dind"
+checkout_dir="${base_dir}/terminal-bench-${tb3_ref}"
+run_dir="${base_dir}/harbor-oracle-${tb3_task}-${tb3_ref}"
+trials_dir="${run_dir}/trials"
+trial_name="${tb3_task}-oracle-$(date +%Y%m%d%H%M%S)-$$"
+result_file="${trials_dir}/${trial_name}/result.json"
+
+print_command() {
+  local argument
+  if [[ -z "${NO_COLOR:-}" ]]; then
+    printf '\033[1;36m' >&2
+  fi
+  printf '$' >&2
+  for argument in "$@"; do
+    printf ' %q' "${argument}" >&2
+  done
+  if [[ -z "${NO_COLOR:-}" ]]; then
+    printf '\033[0m' >&2
+  fi
+  printf '\n' >&2
+}
+
+run_command() {
+  print_command "$@"
+  "$@"
+}
+
+fail() {
+  printf 'Harbor Oracle validation: FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# 该 runner 必须在 DinD Sandbox 内以 root 执行，Harbor 会直接连接内层 Docker daemon。
+[[ "$(id -u)" == "0" ]] || fail "the runner must execute as root"
+run_command docker info >/dev/null
+run_command docker compose version
+
+# Harbor 和 TB3 的下载、镜像构建都发生在 Sandbox 内，不依赖本机 Python 或 Docker。
+printf 'Installing the tools required by Harbor\n'
+run_command apk add --no-cache coreutils curl git python3
+if ! command -v uv >/dev/null 2>&1; then
+  print_command curl -LsSf https://astral.sh/uv/install.sh
+  curl -LsSf https://astral.sh/uv/install.sh \
+    | env UV_INSTALL_DIR=/usr/local/bin sh
+fi
+run_command uv --version
+
+# 固定 TB3 版本并只检出当前 Compose 任务；重复运行时复用数据盘上的 checkout。
+run_command mkdir -p "${base_dir}" "${trials_dir}"
+if [[ ! -d "${checkout_dir}/.git" ]]; then
+  run_command git clone \
+    --depth 1 \
+    --filter=blob:none \
+    --sparse \
+    --branch "${tb3_ref}" \
+    https://github.com/harbor-framework/terminal-bench.git \
+    "${checkout_dir}"
+  run_command git -C "${checkout_dir}" sparse-checkout set "tasks/${tb3_task}"
+else
+  printf 'Reusing Terminal-Bench checkout at %s\n' "${checkout_dir}"
+fi
+
+task_dir="${checkout_dir}/tasks/${tb3_task}"
+[[ -f "${task_dir}/task.toml" ]] || fail "task.toml is missing from ${task_dir}"
+checkout_tag="$(git -C "${checkout_dir}" describe --tags --exact-match 2>/dev/null || true)"
+[[ "${checkout_tag}" == "${tb3_ref}" ]] \
+  || fail "checkout is at ${checkout_tag:-an unexpected revision}, expected ${tb3_ref}"
+
+# Harbor 原生完成完整生命周期：启动原始 Compose 环境、运行 Oracle、按 task.toml
+# 收集跨 service artifacts、启动 separate verifier，并在结束后清理 Compose 资源。
+printf 'Running Terminal-Bench %s with Harbor %s Oracle\n' "${tb3_task}" "${harbor_version}"
+run_command uvx --from "harbor==${harbor_version}" harbor trial start \
+  --path "${task_dir}" \
+  --agent oracle \
+  --env docker \
+  --trial-name "${trial_name}" \
+  --trials-dir "${trials_dir}"
+
+# 再读取 Harbor 生成的结构化结果，避免只依赖终端日志判断成功。
+[[ -f "${result_file}" ]] || fail "Harbor did not write ${result_file}"
+run_command python3 - "${result_file}" "${tb3_task}" <<'PY'
+import json
+import sys
+
+result_path, expected_task = sys.argv[1:]
+with open(result_path, encoding="utf-8") as handle:
+    result = json.load(handle)
+
+if result.get("task_name") != f"terminal-bench/{expected_task}":
+    raise SystemExit(f"unexpected task: {result.get('task_name')}")
+if result.get("exception_info") is not None:
+    raise SystemExit(f"trial failed: {result['exception_info']}")
+if result.get("verifier_environment_mode") != "separate":
+    raise SystemExit("the verifier did not run in separate mode")
+reward = (result.get("verifier_result") or {}).get("rewards", {}).get("reward")
+if reward != 1.0:
+    raise SystemExit(f"expected reward 1.0, got {reward!r}")
+
+print(f"Harbor Oracle validation: PASS ({result_path})")
+PY

--- a/examples/dind/scripts/run-harbor-oracle.sh
+++ b/examples/dind/scripts/run-harbor-oracle.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# shellcheck source=common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+require_command "${AGR_BIN}"
+
+instance_id="$(read_id AGS_INSTANCE_ID "${ROOT_DIR}/.instance-id")"
+run_suffix="$(date +%Y%m%d%H%M%S)-$$"
+remote_script="/workspace/run-harbor-oracle-${run_suffix}.sh"
+remote_script_uploaded=0
+
+# 本地脚本只负责通过 envd 上传和启动 runner；Harbor、TB3 和构建产物均留在 Sandbox 内。
+cleanup_remote() {
+  if (( remote_script_uploaded )); then
+    printf 'Removing the temporary Sandbox script\n'
+    print_agr_command instance exec "${instance_id}" --user root -- \
+      rm -f "${remote_script}"
+    agr_cli instance exec "${instance_id}" --user root -- \
+      rm -f "${remote_script}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup_remote EXIT
+
+printf 'Uploading the Harbor Oracle runner\n'
+print_agr_command instance file upload \
+  "${instance_id}" \
+  "${ROOT_DIR}/scripts/run-harbor-oracle-in-sandbox.sh" \
+  "${remote_script}" \
+  --user root
+agr_cli instance file upload \
+  "${instance_id}" \
+  "${ROOT_DIR}/scripts/run-harbor-oracle-in-sandbox.sh" \
+  "${remote_script}" \
+  --user root
+remote_script_uploaded=1
+
+printf 'Running the Terminal-Bench task with Harbor Oracle in the Sandbox\n'
+print_agr_command instance exec "${instance_id}" \
+  --user root --stream -- bash "${remote_script}"
+agr_cli instance exec "${instance_id}" \
+  --user root \
+  --stream \
+  -- \
+  bash "${remote_script}"

--- a/examples/dind/scripts/start-instance.sh
+++ b/examples/dind/scripts/start-instance.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# shellcheck source=common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+require_command "${AGR_BIN}"
+tool_id="$(read_id AGS_TOOL_ID "${ROOT_DIR}/.tool-id")"
+
+printf 'Creating Sandbox\n'
+print_agr_command instance create \
+  --tool-id "${tool_id}" \
+  --timeout "${AGS_INSTANCE_TIMEOUT}" \
+  -o json \
+  --jq '.Data.InstanceId'
+if ! instance_id="$(
+  agr_cli instance create \
+    --tool-id "${tool_id}" \
+    --timeout "${AGS_INSTANCE_TIMEOUT}" \
+    -o json \
+    --jq '.Data.InstanceId'
+)"; then
+  printf '%s\n' "${instance_id}" >&2
+  exit 1
+fi
+if [[ -z "${instance_id}" || "${instance_id}" == "null" ]]; then
+  printf 'Instance creation did not return an Instance ID\n' >&2
+  exit 1
+fi
+printf '%s\n' "${instance_id}" > "${ROOT_DIR}/.instance-id"
+printf 'Instance ID: %s\n' "${instance_id}"
+
+deadline=$((SECONDS + 360))
+last_state=""
+printf 'Waiting for the Sandbox to enter RUNNING state\n'
+print_agr_command instance get "${instance_id}" -o json --jq '.Data.Status'
+while :; do
+  if ! instance_state="$(agr_cli instance get "${instance_id}" -o json --jq '.Data.Status' 2>/dev/null | tr -d '"[:space:]')"; then
+    instance_state="temporarily-unavailable"
+  fi
+  if [[ "${instance_state}" != "${last_state}" ]]; then
+    printf 'Instance status: %s\n' "${instance_state}"
+    last_state="${instance_state}"
+  fi
+  case "${instance_state}" in
+    RUNNING|running)
+      break
+      ;;
+    FAILED|failed|STOPPED|stopped|STOP_FAILED|stop_failed)
+      printf 'Instance entered terminal state: %s\n' "${instance_state}" >&2
+      exit 1
+      ;;
+  esac
+  (( SECONDS < deadline )) || {
+    printf 'Instance did not become RUNNING within 360 seconds; last state: %s\n' "${instance_state}" >&2
+    exit 1
+  }
+  sleep 3
+done
+
+readiness_command='test "$(id -u)" = 0 && test "${ENVD_DISTRIBUTION:-}" = 0.5.14-oci && test "$PWD" = /workspace && docker info >/dev/null 2>&1 && docker compose version >/dev/null 2>&1'
+printf 'Waiting for envd and the inner Docker daemon\n'
+print_agr_command instance exec "${instance_id}" \
+  --user "${AGS_EXEC_USER}" -- sh -lc "${readiness_command}"
+exec_deadline=$((SECONDS + 60))
+until agr_cli instance exec "${instance_id}" --user "${AGS_EXEC_USER}" -- \
+  sh -lc "${readiness_command}" >/dev/null 2>&1; do
+  (( SECONDS < exec_deadline )) || {
+    printf 'envd data plane did not become ready within 60 seconds\n' >&2
+    exit 1
+  }
+  sleep 3
+done
+
+printf 'Running Sandbox diagnostics through envd\n'
+print_agr_command instance exec "${instance_id}" \
+  --user "${AGS_EXEC_USER}" --stream -- bash -lc '<diagnostic commands shown below>'
+agr_cli instance exec "${instance_id}" \
+  --user "${AGS_EXEC_USER}" \
+  --stream \
+  -- \
+  bash -lc '
+    set -e
+
+    print_remote_command() {
+      if [[ -z "${NO_COLOR:-}" ]]; then
+        printf "\n\033[1;36m$ %s\033[0m\n" "$*"
+      else
+        printf "\n$ %s\n" "$*"
+      fi
+    }
+
+    print_remote_command id
+    id
+
+    print_remote_command pwd
+    pwd
+
+    print_remote_command "envd -version"
+    envd -version
+
+    print_remote_command "docker version --format ..."
+    docker version --format "Docker Engine client: {{.Client.Version}}\nDocker Engine server: {{.Server.Version}}"
+
+    print_remote_command "docker compose version"
+    docker compose version
+
+    print_remote_command "docker info --format ..."
+    docker info --format "Storage driver: {{.Driver}}\nDocker root dir: {{.DockerRootDir}}\nCgroup version: {{.CgroupVersion}}" 2>/dev/null
+
+    print_remote_command "findmnt -T /mnt"
+    findmnt -T /mnt -o SOURCE,FSTYPE,TARGET
+
+    print_remote_command "findmnt -T /var/lib/docker"
+    findmnt -T /var/lib/docker -o SOURCE,FSTYPE,TARGET
+
+    print_remote_command "df -h /mnt /var/lib/docker /var/lib/containerd"
+    df -h /mnt /var/lib/docker /var/lib/containerd
+  '
+
+printf 'DinD sandbox is ready. Saved to %s\n' "${ROOT_DIR}/.instance-id"

--- a/examples/dind/tool-custom-configuration.hk.json
+++ b/examples/dind/tool-custom-configuration.hk.json
@@ -1,0 +1,32 @@
+{
+  "Image": "hkccr.ccs.tencentyun.com/ags-image/dind:v1.0.0",
+  "ImageRegistryType": "custom",
+  "ImageDigest": "sha256:b1332e5cfaeaa335e1c3aae69ffd8a84b42dd78e014247e972d56003338595d3",
+  "Command": [
+    "/usr/local/bin/ags-dind-entrypoint"
+  ],
+  "Ports": [
+    {
+      "Name": "envd",
+      "Port": 49983,
+      "Protocol": "TCP"
+    }
+  ],
+  "Resources": {
+    "CPU": "4",
+    "Memory": "8Gi",
+    "Storage": "20Gi"
+  },
+  "Probe": {
+    "HttpGet": {
+      "Path": "/health",
+      "Port": 49983,
+      "Scheme": "HTTP"
+    },
+    "ReadyTimeoutMs": 30000,
+    "ProbeTimeoutMs": 2000,
+    "ProbePeriodMs": 1000,
+    "SuccessThreshold": 1,
+    "FailureThreshold": 100
+  }
+}


### PR DESCRIPTION
## Summary

Add a Docker-in-Docker (DinD) cookbook for AGS. The example provides a self-starting custom Tool image with Docker Engine, Docker Compose, and envd ready to use.

## Changes

- Add a DinD image based on `docker:29.3.1-dind`
- Start and supervise `dockerd` and `envd` automatically
- Store Docker and containerd data on the AGS-provided data disk
- Add an AGS custom Tool configuration for the Hong Kong region
- Add scripts to create, start, validate, and clean up the Tool and Sandbox
- Add an end-to-end Harbor Oracle validation using a real Terminal-Bench Compose task
- Add English and Chinese documentation
- Update the root and examples indexes

## Validation

- Ran Bash syntax checks for the entrypoint and helper scripts
- Verified the DinD Makefile targets with a dry run
- Ran `git diff --check`
- The Harbor Oracle workflow expects a final reward of `1.0`

## Usage

```bash
cd examples/dind
cp .env.example .env
make run